### PR TITLE
Fix helm lint for service-base chart

### DIFF
--- a/charts/teams/templates/service-base.yaml
+++ b/charts/teams/templates/service-base.yaml
@@ -1,8 +1,15 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+---
+{{ include "service-base.serviceAccount" . }}
+---
+{{ include "service-base.service" . }}
+---
+{{ include "service-base.deployment" . }}
+---
+{{ include "service-base.hpa" . }}
+---
+{{ include "service-base.ingress" . }}
+---
+{{ include "service-base.pdb" . }}
+---
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- add YAML document separators between service-base template includes
- align include formatting with agents-orchestrator chart

## Testing
- go test ./...
- go build ./...
- helm lint charts/teams

Fixes #9