### PR TITLE
Use numeric UID for teams runtime user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /app
 
 COPY --from=build /out/teams /app/teams
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -g 10001 -S app && adduser -u 10001 -S app -G app
 
-USER app
+USER 10001
 
 ENTRYPOINT ["/app/teams"]


### PR DESCRIPTION
## Summary
- create the app user/group with UID/GID 10001
- switch runtime to numeric USER 10001 for runAsNonRoot compatibility

## Testing
- buf generate --path agynio/api/teams/v1
- go test ./...
- go build ./...
- helm dependency build charts/teams
- helm lint charts/teams

Fixes #11