### PR TITLE
feat(agents): persist idle_timeout

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -24,7 +24,7 @@ func toProtoComputeResources(resources store.ComputeResources) *agentsv1.Compute
 }
 
 func toProtoAgent(agent store.Agent) *agentsv1.Agent {
-	return &agentsv1.Agent{
+	protoAgent := &agentsv1.Agent{
 		Meta:           toProtoEntityMeta(agent.Meta),
 		OrganizationId: agent.OrganizationID.String(),
 		Name:           agent.Name,
@@ -36,6 +36,10 @@ func toProtoAgent(agent store.Agent) *agentsv1.Agent {
 		InitImage:      agent.InitImage,
 		Resources:      toProtoComputeResources(agent.Resources),
 	}
+	if agent.IdleTimeout != nil {
+		protoAgent.IdleTimeout = agent.IdleTimeout
+	}
+	return protoAgent
 }
 
 func toProtoVolume(volume store.Volume) *agentsv1.Volume {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"time"
 
 	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
 	identityv1 "github.com/agynio/agents/.gen/go/agynio/api/identity/v1"
@@ -21,7 +22,10 @@ type Server struct {
 	identity IdentityWriter
 }
 
-const maxMcpNameLength = 63
+const (
+	maxMcpNameLength   = 63
+	defaultIdleTimeout = "5m"
+)
 
 var mcpNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
 
@@ -58,6 +62,13 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	if req.GetInitImage() == "" {
 		return nil, status.Error(codes.InvalidArgument, "init_image is required")
 	}
+	idleTimeout := defaultIdleTimeout
+	if req.IdleTimeout != nil {
+		idleTimeout = req.GetIdleTimeout()
+	}
+	if err := validateDurationString(idleTimeout); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "idle_timeout: %v", err)
+	}
 	resources := toStoreComputeResources(req.GetResources())
 	agent, err := s.store.CreateAgent(ctx, organizationID, store.AgentInput{
 		Name:          req.GetName(),
@@ -67,6 +78,7 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 		Configuration: req.GetConfiguration(),
 		Image:         req.GetImage(),
 		InitImage:     req.GetInitImage(),
+		IdleTimeout:   &idleTimeout,
 		Resources:     resources,
 	})
 	if err != nil {
@@ -109,7 +121,7 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	if req.Name == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.Resources == nil {
+	if req.Name == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	if req.InitImage != nil && req.GetInitImage() == "" {
@@ -147,6 +159,13 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	if req.InitImage != nil {
 		value := req.GetInitImage()
 		update.InitImage = &value
+	}
+	if req.IdleTimeout != nil {
+		value := req.GetIdleTimeout()
+		if err := validateDurationString(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "idle_timeout: %v", err)
+		}
+		update.IdleTimeout = &value
 	}
 	if req.Resources != nil {
 		resources := toStoreComputeResources(req.GetResources())
@@ -1148,6 +1167,16 @@ func validateMcpName(name string) error {
 	}
 	if !mcpNamePattern.MatchString(name) {
 		return fmt.Errorf("must match %s", mcpNamePattern.String())
+	}
+	return nil
+}
+
+func validateDurationString(value string) error {
+	if value == "" {
+		return fmt.Errorf("value is empty")
+	}
+	if _, err := time.ParseDuration(value); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1175,8 +1175,12 @@ func validateDurationString(value string) error {
 	if value == "" {
 		return fmt.Errorf("value is empty")
 	}
-	if _, err := time.ParseDuration(value); err != nil {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
 		return err
+	}
+	if duration <= 0 {
+		return fmt.Errorf("must be a positive duration")
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	agentColumns                     = `id, organization_id, name, role, model, description, configuration, image, init_image, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, created_at, updated_at`
+	agentColumns                     = `id, organization_id, name, role, model, description, configuration, image, init_image, idle_timeout, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, created_at, updated_at`
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, image_pull_secret_id, agent_id, mcp_id, hook_id, created_at, updated_at`
@@ -50,6 +50,7 @@ func stringPtrFromPg(value pgtype.Text) *string {
 
 func scanAgent(row pgx.Row) (Agent, error) {
 	var agent Agent
+	var idleTimeout pgtype.Text
 	if err := row.Scan(
 		&agent.Meta.ID,
 		&agent.OrganizationID,
@@ -60,6 +61,7 @@ func scanAgent(row pgx.Row) (Agent, error) {
 		&agent.Configuration,
 		&agent.Image,
 		&agent.InitImage,
+		&idleTimeout,
 		&agent.Resources.RequestsCPU,
 		&agent.Resources.RequestsMemory,
 		&agent.Resources.LimitsCPU,
@@ -69,6 +71,7 @@ func scanAgent(row pgx.Row) (Agent, error) {
 	); err != nil {
 		return Agent{}, err
 	}
+	agent.IdleTimeout = stringPtrFromPg(idleTimeout)
 	return agent, nil
 }
 
@@ -245,8 +248,8 @@ func scanInitScript(row pgx.Row) (InitScript, error) {
 
 func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input AgentInput) (Agent, error) {
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO agents (organization_id, name, role, model, description, configuration, image, init_image, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		fmt.Sprintf(`INSERT INTO agents (organization_id, name, role, model, description, configuration, image, init_image, idle_timeout, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 		 RETURNING %s`, agentColumns),
 		organizationID,
 		input.Name,
@@ -256,6 +259,7 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		input.Configuration,
 		input.Image,
 		input.InitImage,
+		input.IdleTimeout,
 		input.Resources.RequestsCPU,
 		input.Resources.RequestsMemory,
 		input.Resources.LimitsCPU,
@@ -305,6 +309,9 @@ func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdat
 	}
 	if update.InitImage != nil {
 		builder.add("init_image", *update.InitImage)
+	}
+	if update.IdleTimeout != nil {
+		builder.add("idle_timeout", *update.IdleTimeout)
 	}
 	if update.Resources != nil {
 		builder.add("resources_requests_cpu", update.Resources.RequestsCPU)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -29,6 +29,7 @@ type Agent struct {
 	Configuration  string
 	Image          string
 	InitImage      string
+	IdleTimeout    *string
 	Resources      ComputeResources
 }
 
@@ -113,6 +114,7 @@ type AgentInput struct {
 	Configuration string
 	Image         string
 	InitImage     string
+	IdleTimeout   *string
 	Resources     ComputeResources
 }
 
@@ -124,6 +126,7 @@ type AgentUpdate struct {
 	Configuration *string
 	Image         *string
 	InitImage     *string
+	IdleTimeout   *string
 	Resources     *ComputeResources
 }
 

--- a/migrations/0010_add_idle_timeout.sql
+++ b/migrations/0010_add_idle_timeout.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agents
+    ADD COLUMN idle_timeout TEXT;


### PR DESCRIPTION
## Summary
- add idle_timeout column on agents and wire store reads/writes
- validate and default idle_timeout on create/update requests
- include idle_timeout in agent responses when stored

## Testing
- go test ./...

Refs #119