### PR TITLE
Bump agent init image tags

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	listPageSize  int32 = 50
-	testInitImage       = "ghcr.io/agynio/agent-init-codex:v1.0.0"
+	testInitImage       = "ghcr.io/agynio/agent-init-codex:0.13.24"
 )
 
 func TestAgentsServiceE2E(t *testing.T) {
@@ -84,11 +84,11 @@ func TestAgentsServiceE2E(t *testing.T) {
 		updatedAgentResp, err := client.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
 			Id:        agentID1,
 			Name:      proto.String("Agent Alpha Updated " + testID),
-			InitImage: proto.String("ghcr.io/agynio/agent-init-codex:v1.0.1"),
+			InitImage: proto.String(testInitImage),
 		})
 		require.NoError(t, err)
 		require.Equal(t, "Agent Alpha Updated "+testID, updatedAgentResp.Agent.Name)
-		require.Equal(t, "ghcr.io/agynio/agent-init-codex:v1.0.1", updatedAgentResp.Agent.InitImage)
+		require.Equal(t, testInitImage, updatedAgentResp.Agent.InitImage)
 
 		listAgentsResp1, err := client.ListAgents(ctx, &agentsv1.ListAgentsRequest{OrganizationId: testOrganizationID, PageSize: 1})
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Bumps the pinned `ghcr.io/agynio/agent-init-codex` references in `test/e2e/e2e_test.go` to `0.13.24`.
- Reuses the shared `testInitImage` constant for the update assertion to keep the E2E fixture pinned in one place.
- Checked this repo for other `ghcr.io/agynio/agent-init-*:<tag>` references; no `agent-init-claude` or `agent-init-agn` references are present here.

Closes #49

## Test & Lint Summary
- `gofmt -w test/e2e/e2e_test.go && test -z "$(gofmt -l test/e2e/e2e_test.go)"`: passed with no formatting differences.
- `GOTOOLCHAIN=local go test -v ./...`: 2 passed, 0 failed, 0 skipped.
- `GOTOOLCHAIN=local go build ./...`: passed.

Note: `GOTOOLCHAIN=local go test -v -tags e2e ./test/e2e/` was started locally, but it requires a running Agents service at `agents:50051` and could not complete in this workspace without the DevSpace/Kubernetes E2E environment.