### PR TITLE
feat: add agent availability roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
         run: |
           if [ -n "${AGYNIO_API_REF:-}" ]; then
             buf generate "https://github.com/agynio/api.git#${AGYNIO_API_REF}" --path proto/agynio/api/agents/v1 --path proto/agynio/api/authorization/v1 --path proto/agynio/api/identity/v1 --path proto/agynio/api/notifications/v1
-            mkdir -p .gen/go/agynio/api/agents/v1 .gen/go/agynio/api/authorization/v1 .gen/go/agynio/api/identity/v1 .gen/go/agynio/api/notifications/v1
-            mv .gen/go/proto/agynio/api/agents/v1/* .gen/go/agynio/api/agents/v1/
-            mv .gen/go/proto/agynio/api/authorization/v1/* .gen/go/agynio/api/authorization/v1/
-            mv .gen/go/proto/agynio/api/identity/v1/* .gen/go/agynio/api/identity/v1/
-            mv .gen/go/proto/agynio/api/notifications/v1/* .gen/go/agynio/api/notifications/v1/
           else
             buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,19 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
+        run: |
+          if [ -n "${AGYNIO_API_REF:-}" ]; then
+            buf generate "https://github.com/agynio/api.git#${AGYNIO_API_REF}" --path proto/agynio/api/agents/v1 --path proto/agynio/api/authorization/v1 --path proto/agynio/api/identity/v1 --path proto/agynio/api/notifications/v1
+            mkdir -p .gen/go/agynio/api/agents/v1 .gen/go/agynio/api/authorization/v1 .gen/go/agynio/api/identity/v1 .gen/go/agynio/api/notifications/v1
+            mv .gen/go/proto/agynio/api/agents/v1/* .gen/go/agynio/api/agents/v1/
+            mv .gen/go/proto/agynio/api/authorization/v1/* .gen/go/agynio/api/authorization/v1/
+            mv .gen/go/proto/agynio/api/identity/v1/* .gen/go/agynio/api/identity/v1/
+            mv .gen/go/proto/agynio/api/notifications/v1/* .gen/go/agynio/api/notifications/v1/
+          else
+            buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
+          fi
+        env:
+          AGYNIO_API_REF: branch=noa/issue-51-agent-availability
 
       - name: Run tests
         run: go test ./...

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -4,23 +4,44 @@ import (
 	"context"
 
 	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
 	identityPrefix     = "identity:"
 	organizationPrefix = "organization:"
-	memberRelation     = "member"
+	agentPrefix        = "agent:"
 )
 
 type AuthorizationWriter interface {
+	Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
 	Write(ctx context.Context, req *authorizationv1.WriteRequest, opts ...grpc.CallOption) (*authorizationv1.WriteResponse, error)
+}
+
+func (s *Server) requireOrganizationMember(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
+	response, err := s.authz.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     identityPrefix + identityID.String(),
+			Relation: "member",
+			Object:   organizationPrefix + organizationID.String(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if !response.GetAllowed() {
+		return status.Error(codes.InvalidArgument, "identity is not a member of the agent organization")
+	}
+	return nil
 }
 
 func (s *Server) addAgentMembership(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID) error {
 	return s.writeAuthorization(ctx,
-		[]*authorizationv1.TupleKey{authorizationTuple(agentID, organizationID)},
+		[]*authorizationv1.TupleKey{agentOrganizationTuple(agentID, organizationID)},
 		nil,
 	)
 }
@@ -28,8 +49,54 @@ func (s *Server) addAgentMembership(ctx context.Context, agentID uuid.UUID, orga
 func (s *Server) removeAgentMembership(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID) error {
 	return s.writeAuthorization(ctx,
 		nil,
-		[]*authorizationv1.TupleKey{authorizationTuple(agentID, organizationID)},
+		[]*authorizationv1.TupleKey{agentOrganizationTuple(agentID, organizationID)},
 	)
+}
+
+func (s *Server) addAgentAuthorization(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID, creatorID uuid.UUID, availability store.AgentAvailability) error {
+	writes := []*authorizationv1.TupleKey{
+		agentOrganizationTuple(agentID, organizationID),
+		agentRoleTuple(agentID, creatorID, store.AgentRoleOwner),
+	}
+	if availability == store.AgentAvailabilityInternal {
+		writes = append(writes, agentInternalAccessTuple(agentID, organizationID))
+	}
+	return s.writeAuthorization(ctx, writes, nil)
+}
+
+func (s *Server) removeAgentAuthorization(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID, roles []store.AgentRoleAssignment, availability store.AgentAvailability) error {
+	deletes := []*authorizationv1.TupleKey{agentOrganizationTuple(agentID, organizationID)}
+	if availability == store.AgentAvailabilityInternal {
+		deletes = append(deletes, agentInternalAccessTuple(agentID, organizationID))
+	}
+	for _, role := range roles {
+		deletes = append(deletes, agentRoleTuple(agentID, role.IdentityID, role.Role))
+	}
+	return s.writeAuthorization(ctx, nil, deletes)
+}
+
+func (s *Server) updateAgentAvailabilityAuthorization(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID, previous, next store.AgentAvailability) error {
+	if previous == next {
+		return nil
+	}
+	tuple := agentInternalAccessTuple(agentID, organizationID)
+	if next == store.AgentAvailabilityInternal {
+		return s.writeAuthorization(ctx, []*authorizationv1.TupleKey{tuple}, nil)
+	}
+	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{tuple})
+}
+
+func (s *Server) updateAgentRoleAuthorization(ctx context.Context, agentID uuid.UUID, identityID uuid.UUID, previous *store.AgentRole, next store.AgentRole) error {
+	writes := []*authorizationv1.TupleKey{agentRoleTuple(agentID, identityID, next)}
+	var deletes []*authorizationv1.TupleKey
+	if previous != nil && *previous != next {
+		deletes = []*authorizationv1.TupleKey{agentRoleTuple(agentID, identityID, *previous)}
+	}
+	return s.writeAuthorization(ctx, writes, deletes)
+}
+
+func (s *Server) removeAgentRoleAuthorization(ctx context.Context, agentID uuid.UUID, identityID uuid.UUID, role store.AgentRole) error {
+	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{agentRoleTuple(agentID, identityID, role)})
 }
 
 func (s *Server) writeAuthorization(ctx context.Context, writes []*authorizationv1.TupleKey, deletes []*authorizationv1.TupleKey) error {
@@ -40,10 +107,26 @@ func (s *Server) writeAuthorization(ctx context.Context, writes []*authorization
 	return err
 }
 
-func authorizationTuple(agentID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+func agentOrganizationTuple(agentID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
 	return &authorizationv1.TupleKey{
-		User:     identityPrefix + agentID.String(),
-		Relation: memberRelation,
-		Object:   organizationPrefix + organizationID.String(),
+		User:     organizationPrefix + organizationID.String(),
+		Relation: "org",
+		Object:   agentPrefix + agentID.String(),
+	}
+}
+
+func agentInternalAccessTuple(agentID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     organizationPrefix + organizationID.String(),
+		Relation: "internal_access",
+		Object:   agentPrefix + agentID.String(),
+	}
+}
+
+func agentRoleTuple(agentID uuid.UUID, identityID uuid.UUID, role store.AgentRole) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + identityID.String(),
+		Relation: string(role),
+		Object:   agentPrefix + agentID.String(),
 	}
 }

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -36,12 +36,21 @@ func toProtoAgent(agent store.Agent) *agentsv1.Agent {
 		Image:          agent.Image,
 		InitImage:      agent.InitImage,
 		Capabilities:   append([]string(nil), agent.Capabilities...),
+		Availability:   agentAvailabilityToProto(agent.Availability),
 		Resources:      toProtoComputeResources(agent.Resources),
 	}
 	if agent.IdleTimeout != nil {
 		protoAgent.IdleTimeout = agent.IdleTimeout
 	}
 	return protoAgent
+}
+
+func toProtoAgentRoleAssignment(assignment store.AgentRoleAssignment) *agentsv1.AgentRoleAssignment {
+	return &agentsv1.AgentRoleAssignment{
+		AgentId:    assignment.AgentID.String(),
+		IdentityId: assignment.IdentityID.String(),
+		Role:       agentRoleToProto(assignment.Role),
+	}
 }
 
 func toProtoVolume(volume store.Volume) *agentsv1.Volume {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -438,9 +438,20 @@ func (s *Server) SetAgentRole(ctx context.Context, req *agentsv1.SetAgentRoleReq
 		return nil, toStatusError(err)
 	}
 	if err := s.updateAgentRoleAuthorization(ctx, agent.Meta.ID, identityID, previousRole, role); err != nil {
+		if rollbackErr := s.restoreAgentRoleAssignment(ctx, previousRole, assignment); rollbackErr != nil {
+			return nil, status.Errorf(codes.Internal, "authorization write failed: %v; rollback failed: %v", err, rollbackErr)
+		}
 		return nil, status.Errorf(codes.Internal, "authorization write failed: %v", err)
 	}
 	return &agentsv1.SetAgentRoleResponse{Assignment: toProtoAgentRoleAssignment(assignment)}, nil
+}
+
+func (s *Server) restoreAgentRoleAssignment(ctx context.Context, previousRole *store.AgentRole, next store.AgentRoleAssignment) error {
+	if previousRole != nil {
+		_, err := s.store.UpsertAgentRole(ctx, store.AgentRoleAssignment{AgentID: next.AgentID, IdentityID: next.IdentityID, Role: *previousRole})
+		return err
+	}
+	return s.store.DeleteAgentRoleIfExists(ctx, next.AgentID, next.IdentityID)
 }
 
 func (s *Server) RemoveAgentRole(ctx context.Context, req *agentsv1.RemoveAgentRoleRequest) (*agentsv1.RemoveAgentRoleResponse, error) {
@@ -457,6 +468,9 @@ func (s *Server) RemoveAgentRole(ctx context.Context, req *agentsv1.RemoveAgentR
 		return nil, toStatusError(err)
 	}
 	if err := s.removeAgentRoleAuthorization(ctx, agentID, identityID, assignment.Role); err != nil {
+		if _, rollbackErr := s.store.UpsertAgentRole(ctx, assignment); rollbackErr != nil {
+			return nil, status.Errorf(codes.Internal, "authorization delete failed: %v; rollback failed: %v", err, rollbackErr)
+		}
 		return nil, status.Errorf(codes.Internal, "authorization delete failed: %v", err)
 	}
 	return &agentsv1.RemoveAgentRoleResponse{}, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/agents/.gen/go/agynio/api/identity/v1"
 	notificationsv1 "github.com/agynio/agents/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents/internal/store"
@@ -113,6 +114,18 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	if req.GetInitImage() == "" {
 		return nil, status.Error(codes.InvalidArgument, "init_image is required")
 	}
+	creatorIDValue, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	creatorID, err := parseUUID(creatorIDValue)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	availability, err := agentAvailabilityFromProto(req.GetAvailability())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "availability: %v", err)
+	}
 	idleTimeout := defaultIdleTimeout
 	if req.IdleTimeout != nil {
 		idleTimeout = req.GetIdleTimeout()
@@ -133,12 +146,21 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 		InitImage:     req.GetInitImage(),
 		IdleTimeout:   &idleTimeout,
 		Capabilities:  append([]string(nil), req.GetCapabilities()...),
+		Availability:  availability,
 		Resources:     resources,
 	})
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.addAgentMembership(ctx, agent.Meta.ID, agent.OrganizationID); err != nil {
+	creatorRole := store.AgentRoleAssignment{AgentID: agent.Meta.ID, IdentityID: creatorID, Role: store.AgentRoleOwner}
+	if _, err := s.store.UpsertAgentRole(ctx, creatorRole); err != nil {
+		rollbackErr := s.store.DeleteAgent(ctx, agent.Meta.ID)
+		if rollbackErr != nil {
+			return nil, status.Errorf(codes.Internal, "store role failed: %v; rollback failed: %v", err, rollbackErr)
+		}
+		return nil, status.Errorf(codes.Internal, "store role failed: %v", err)
+	}
+	if err := s.addAgentAuthorization(ctx, agent.Meta.ID, agent.OrganizationID, creatorID, availability); err != nil {
 		rollbackErr := s.store.DeleteAgent(ctx, agent.Meta.ID)
 		if rollbackErr != nil {
 			return nil, status.Errorf(codes.Internal, "authorization write failed: %v; rollback failed: %v", err, rollbackErr)
@@ -147,7 +169,7 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	}
 	if err := s.registerAgentIdentity(ctx, agent.Meta.ID); err != nil {
 		rollbackErr := errors.Join(
-			s.removeAgentMembership(ctx, agent.Meta.ID, agent.OrganizationID),
+			s.removeAgentAuthorization(ctx, agent.Meta.ID, agent.OrganizationID, []store.AgentRoleAssignment{creatorRole}, availability),
 			s.store.DeleteAgent(ctx, agent.Meta.ID),
 		)
 		if rollbackErr != nil {
@@ -164,7 +186,7 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 			}
 			rollbackErr := errors.Join(
 				cleanupErr,
-				s.removeAgentMembership(ctx, agent.Meta.ID, agent.OrganizationID),
+				s.removeAgentAuthorization(ctx, agent.Meta.ID, agent.OrganizationID, []store.AgentRoleAssignment{creatorRole}, availability),
 				s.store.DeleteAgent(ctx, agent.Meta.ID),
 			)
 			if rollbackErr != nil {
@@ -213,7 +235,8 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	// slice indicates the caller did not set capabilities; when provided, the
 	// list replaces existing capabilities.
 	capabilitiesProvided := req.Capabilities != nil
-	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided {
+	availabilityProvided := req.Availability != nil
+	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	if req.InitImage != nil && req.GetInitImage() == "" {
@@ -224,11 +247,13 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	var previousAgent store.Agent
 	var nicknameValue string
 	var nicknameUpdateNeeded bool
-	if nicknameProvided {
+	if nicknameProvided || availabilityProvided {
 		previousAgent, err = s.store.GetAgent(ctx, id)
 		if err != nil {
 			return nil, toStatusError(err)
 		}
+	}
+	if nicknameProvided {
 		nicknameValue = req.GetNickname()
 		nicknameUpdateNeeded = nicknameValue != previousAgent.Nickname
 	}
@@ -280,6 +305,13 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 		value := append([]string(nil), req.GetCapabilities()...)
 		update.Capabilities = &value
 	}
+	if availabilityProvided {
+		value, err := agentAvailabilityFromProto(req.GetAvailability())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "availability: %v", err)
+		}
+		update.Availability = &value
+	}
 	if req.Resources != nil {
 		resources := toStoreComputeResources(req.GetResources())
 		update.Resources = &resources
@@ -305,6 +337,15 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 			return nil, status.Errorf(codes.Internal, "update nickname: %v", nicknameErr)
 		}
 	}
+	if availabilityProvided {
+		if err := s.updateAgentAvailabilityAuthorization(ctx, agent.Meta.ID, agent.OrganizationID, previousAgent.Availability, agent.Availability); err != nil {
+			_, rollbackErr := s.store.UpdateAgent(ctx, id, store.AgentUpdate{Availability: &previousAgent.Availability})
+			if rollbackErr != nil {
+				return nil, status.Errorf(codes.Internal, "update availability authorization: %v; rollback: %v", err, rollbackErr)
+			}
+			return nil, status.Errorf(codes.Internal, "update availability authorization: %v", err)
+		}
+	}
 	s.publishAgentUpdated(ctx, agent.Meta.ID, agent.OrganizationID)
 	return &agentsv1.UpdateAgentResponse{Agent: toProtoAgent(agent)}, nil
 }
@@ -318,13 +359,17 @@ func (s *Server) DeleteAgent(ctx context.Context, req *agentsv1.DeleteAgentReque
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.removeAgentMembership(ctx, agent.Meta.ID, agent.OrganizationID); err != nil {
+	roles, err := s.store.ListAgentRoles(ctx, agent.Meta.ID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.removeAgentAuthorization(ctx, agent.Meta.ID, agent.OrganizationID, roles, agent.Availability); err != nil {
 		return nil, status.Errorf(codes.Internal, "authorization delete failed: %v", err)
 	}
 	removedNickname := false
 	if agent.Nickname != "" {
 		if err := s.removeAgentNickname(ctx, agent.Meta.ID, agent.OrganizationID); err != nil {
-			rollbackErr := s.addAgentMembership(ctx, agent.Meta.ID, agent.OrganizationID)
+			rollbackErr := s.restoreAgentAuthorization(ctx, agent, roles)
 			if rollbackErr != nil {
 				return nil, status.Errorf(codes.Internal, "remove nickname: %v; rollback: %v", err, rollbackErr)
 			}
@@ -333,7 +378,7 @@ func (s *Server) DeleteAgent(ctx context.Context, req *agentsv1.DeleteAgentReque
 		removedNickname = true
 	}
 	if err := s.store.DeleteAgent(ctx, id); err != nil {
-		rollbackErr := s.addAgentMembership(ctx, agent.Meta.ID, agent.OrganizationID)
+		rollbackErr := s.restoreAgentAuthorization(ctx, agent, roles)
 		if removedNickname {
 			rollbackErr = errors.Join(rollbackErr, s.setAgentNickname(ctx, agent.Meta.ID, agent.OrganizationID, agent.Nickname))
 		}
@@ -344,6 +389,117 @@ func (s *Server) DeleteAgent(ctx context.Context, req *agentsv1.DeleteAgentReque
 	}
 	s.publishAgentUpdated(ctx, agent.Meta.ID, agent.OrganizationID)
 	return &agentsv1.DeleteAgentResponse{}, nil
+}
+
+func (s *Server) restoreAgentAuthorization(ctx context.Context, agent store.Agent, roles []store.AgentRoleAssignment) error {
+	writes := []*authorizationv1.TupleKey{agentOrganizationTuple(agent.Meta.ID, agent.OrganizationID)}
+	if agent.Availability == store.AgentAvailabilityInternal {
+		writes = append(writes, agentInternalAccessTuple(agent.Meta.ID, agent.OrganizationID))
+	}
+	for _, role := range roles {
+		writes = append(writes, agentRoleTuple(agent.Meta.ID, role.IdentityID, role.Role))
+	}
+	return s.writeAuthorization(ctx, writes, nil)
+}
+
+func (s *Server) SetAgentRole(ctx context.Context, req *agentsv1.SetAgentRoleRequest) (*agentsv1.SetAgentRoleResponse, error) {
+	agentID, err := parseUUID(req.GetAgentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	role, err := agentRoleFromProto(req.GetRole())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "role: %v", err)
+	}
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireOrganizationMember(ctx, identityID, agent.OrganizationID); err != nil {
+		return nil, status.Errorf(status.Code(err), "organization membership check failed: %v", err)
+	}
+	previousAssignment, err := s.store.GetAgentRole(ctx, agentID, identityID)
+	var previousRole *store.AgentRole
+	if err != nil {
+		var notFound *store.NotFoundError
+		if !errors.As(err, &notFound) {
+			return nil, toStatusError(err)
+		}
+	} else {
+		previousRole = &previousAssignment.Role
+	}
+	assignment := store.AgentRoleAssignment{AgentID: agentID, IdentityID: identityID, Role: role}
+	assignment, err = s.store.UpsertAgentRole(ctx, assignment)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.updateAgentRoleAuthorization(ctx, agent.Meta.ID, identityID, previousRole, role); err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization write failed: %v", err)
+	}
+	return &agentsv1.SetAgentRoleResponse{Assignment: toProtoAgentRoleAssignment(assignment)}, nil
+}
+
+func (s *Server) RemoveAgentRole(ctx context.Context, req *agentsv1.RemoveAgentRoleRequest) (*agentsv1.RemoveAgentRoleResponse, error) {
+	agentID, err := parseUUID(req.GetAgentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	assignment, err := s.store.DeleteAgentRole(ctx, agentID, identityID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.removeAgentRoleAuthorization(ctx, agentID, identityID, assignment.Role); err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization delete failed: %v", err)
+	}
+	return &agentsv1.RemoveAgentRoleResponse{}, nil
+}
+
+func (s *Server) ListAgentRoles(ctx context.Context, req *agentsv1.ListAgentRolesRequest) (*agentsv1.ListAgentRolesResponse, error) {
+	agentID, err := parseUUID(req.GetAgentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+	}
+	assignments, err := s.store.ListAgentRoles(ctx, agentID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	response := &agentsv1.ListAgentRolesResponse{Assignments: make([]*agentsv1.AgentRoleAssignment, len(assignments))}
+	for i, assignment := range assignments {
+		response.Assignments[i] = toProtoAgentRoleAssignment(assignment)
+	}
+	return response, nil
+}
+
+func (s *Server) ListMyAgentRoles(ctx context.Context, req *agentsv1.ListMyAgentRolesRequest) (*agentsv1.ListMyAgentRolesResponse, error) {
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityIDValue, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	identityID, err := parseUUID(identityIDValue)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	assignments, err := s.store.ListIdentityAgentRoles(ctx, organizationID, identityID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	response := &agentsv1.ListMyAgentRolesResponse{Assignments: make([]*agentsv1.AgentRoleAssignment, len(assignments))}
+	for i, assignment := range assignments {
+		response.Assignments[i] = toProtoAgentRoleAssignment(assignment)
+	}
+	return response, nil
 }
 
 func (s *Server) ListAgents(ctx context.Context, req *agentsv1.ListAgentsRequest) (*agentsv1.ListAgentsResponse, error) {
@@ -1400,6 +1556,58 @@ func toStoreComputeResources(resources *agentsv1.ComputeResources) store.Compute
 		RequestsMemory: resources.GetRequestsMemory(),
 		LimitsCPU:      resources.GetLimitsCpu(),
 		LimitsMemory:   resources.GetLimitsMemory(),
+	}
+}
+
+func agentAvailabilityFromProto(availability agentsv1.AgentAvailability) (store.AgentAvailability, error) {
+	switch availability {
+	case agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL:
+		return store.AgentAvailabilityInternal, nil
+	case agentsv1.AgentAvailability_AGENT_AVAILABILITY_PRIVATE:
+		return store.AgentAvailabilityPrivate, nil
+	case agentsv1.AgentAvailability_AGENT_AVAILABILITY_UNSPECIFIED:
+		return "", fmt.Errorf("must be internal or private")
+	default:
+		return "", fmt.Errorf("unknown value %d", availability)
+	}
+}
+
+func agentAvailabilityToProto(availability store.AgentAvailability) agentsv1.AgentAvailability {
+	switch availability {
+	case store.AgentAvailabilityInternal:
+		return agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL
+	case store.AgentAvailabilityPrivate:
+		return agentsv1.AgentAvailability_AGENT_AVAILABILITY_PRIVATE
+	default:
+		panic(fmt.Sprintf("unknown agent availability %q", availability))
+	}
+}
+
+func agentRoleFromProto(role agentsv1.AgentRole) (store.AgentRole, error) {
+	switch role {
+	case agentsv1.AgentRole_AGENT_ROLE_OWNER:
+		return store.AgentRoleOwner, nil
+	case agentsv1.AgentRole_AGENT_ROLE_MAINTAINER:
+		return store.AgentRoleMaintainer, nil
+	case agentsv1.AgentRole_AGENT_ROLE_PARTICIPANT:
+		return store.AgentRoleParticipant, nil
+	case agentsv1.AgentRole_AGENT_ROLE_UNSPECIFIED:
+		return "", fmt.Errorf("must be owner, maintainer, or participant")
+	default:
+		return "", fmt.Errorf("unknown value %d", role)
+	}
+}
+
+func agentRoleToProto(role store.AgentRole) agentsv1.AgentRole {
+	switch role {
+	case store.AgentRoleOwner:
+		return agentsv1.AgentRole_AGENT_ROLE_OWNER
+	case store.AgentRoleMaintainer:
+		return agentsv1.AgentRole_AGENT_ROLE_MAINTAINER
+	case store.AgentRoleParticipant:
+		return agentsv1.AgentRole_AGENT_ROLE_PARTICIPANT
+	default:
+		panic(fmt.Sprintf("unknown agent role %q", role))
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -436,6 +436,19 @@ func (s *Store) UpsertAgentRole(ctx context.Context, assignment AgentRoleAssignm
 }
 
 func (s *Store) DeleteAgentRole(ctx context.Context, agentID, identityID uuid.UUID) (AgentRoleAssignment, error) {
+	return s.deleteAgentRole(ctx, agentID, identityID)
+}
+
+func (s *Store) DeleteAgentRoleIfExists(ctx context.Context, agentID, identityID uuid.UUID) error {
+	_, err := s.deleteAgentRole(ctx, agentID, identityID)
+	var notFound *NotFoundError
+	if errors.As(err, &notFound) {
+		return nil
+	}
+	return err
+}
+
+func (s *Store) deleteAgentRole(ctx context.Context, agentID, identityID uuid.UUID) (AgentRoleAssignment, error) {
 	row := s.pool.QueryRow(ctx,
 		`DELETE FROM agent_roles WHERE agent_id = $1 AND identity_id = $2 RETURNING agent_id, identity_id, role`,
 		agentID,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, created_at, updated_at`
+	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, created_at, updated_at`
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, image_pull_secret_id, agent_id, mcp_id, hook_id, created_at, updated_at`
@@ -91,6 +91,7 @@ func scanAgent(row pgx.Row) (Agent, error) {
 		&agent.InitImage,
 		&idleTimeout,
 		&capabilities,
+		&agent.Availability,
 		&agent.Resources.RequestsCPU,
 		&agent.Resources.RequestsMemory,
 		&agent.Resources.LimitsCPU,
@@ -283,14 +284,40 @@ func scanInitScript(row pgx.Row) (InitScript, error) {
 	return script, nil
 }
 
+func scanAgentRoleAssignment(row pgx.Row) (AgentRoleAssignment, error) {
+	var assignment AgentRoleAssignment
+	if err := row.Scan(&assignment.AgentID, &assignment.IdentityID, &assignment.Role); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentRoleAssignment{}, NotFound("agent role")
+		}
+		return AgentRoleAssignment{}, err
+	}
+	return assignment, nil
+}
+
+func scanAgentRoleAssignments(rows pgx.Rows) ([]AgentRoleAssignment, error) {
+	assignments := []AgentRoleAssignment{}
+	for rows.Next() {
+		assignment, err := scanAgentRoleAssignment(rows)
+		if err != nil {
+			return nil, err
+		}
+		assignments = append(assignments, assignment)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return assignments, nil
+}
+
 func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input AgentInput) (Agent, error) {
 	capabilitiesJSON, err := encodeCapabilities(input.Capabilities)
 	if err != nil {
 		return Agent{}, err
 	}
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		 RETURNING %s`, agentColumns),
 		organizationID,
 		input.Name,
@@ -303,6 +330,7 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		input.InitImage,
 		input.IdleTimeout,
 		capabilitiesJSON,
+		input.Availability,
 		input.Resources.RequestsCPU,
 		input.Resources.RequestsMemory,
 		input.Resources.LimitsCPU,
@@ -366,6 +394,9 @@ func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdat
 		}
 		builder.add("capabilities", capabilitiesJSON)
 	}
+	if update.Availability != nil {
+		builder.add("availability", *update.Availability)
+	}
 	if update.Resources != nil {
 		builder.add("resources_requests_cpu", update.Resources.RequestsCPU)
 		builder.add("resources_requests_memory", update.Resources.RequestsMemory)
@@ -386,6 +417,66 @@ func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdat
 		return Agent{}, err
 	}
 	return agent, nil
+}
+
+func (s *Store) UpsertAgentRole(ctx context.Context, assignment AgentRoleAssignment) (AgentRoleAssignment, error) {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO agent_roles (agent_id, identity_id, role)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (agent_id, identity_id)
+		 DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()`,
+		assignment.AgentID,
+		assignment.IdentityID,
+		assignment.Role,
+	)
+	if err != nil {
+		return AgentRoleAssignment{}, err
+	}
+	return assignment, nil
+}
+
+func (s *Store) DeleteAgentRole(ctx context.Context, agentID, identityID uuid.UUID) (AgentRoleAssignment, error) {
+	row := s.pool.QueryRow(ctx,
+		`DELETE FROM agent_roles WHERE agent_id = $1 AND identity_id = $2 RETURNING agent_id, identity_id, role`,
+		agentID,
+		identityID,
+	)
+	return scanAgentRoleAssignment(row)
+}
+
+func (s *Store) GetAgentRole(ctx context.Context, agentID, identityID uuid.UUID) (AgentRoleAssignment, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT agent_id, identity_id, role FROM agent_roles WHERE agent_id = $1 AND identity_id = $2`,
+		agentID,
+		identityID,
+	)
+	return scanAgentRoleAssignment(row)
+}
+
+func (s *Store) ListAgentRoles(ctx context.Context, agentID uuid.UUID) ([]AgentRoleAssignment, error) {
+	rows, err := s.pool.Query(ctx, `SELECT agent_id, identity_id, role FROM agent_roles WHERE agent_id = $1 ORDER BY identity_id ASC`, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanAgentRoleAssignments(rows)
+}
+
+func (s *Store) ListIdentityAgentRoles(ctx context.Context, organizationID, identityID uuid.UUID) ([]AgentRoleAssignment, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT ar.agent_id, ar.identity_id, ar.role
+		 FROM agent_roles ar
+		 JOIN agents a ON a.id = ar.agent_id
+		 WHERE a.organization_id = $1 AND ar.identity_id = $2
+		 ORDER BY ar.agent_id ASC`,
+		organizationID,
+		identityID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanAgentRoleAssignments(rows)
 }
 
 func (s *Store) DeleteAgent(ctx context.Context, id uuid.UUID) error {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -32,7 +32,29 @@ type Agent struct {
 	InitImage      string
 	IdleTimeout    *string
 	Capabilities   []string
+	Availability   AgentAvailability
 	Resources      ComputeResources
+}
+
+type AgentAvailability string
+
+const (
+	AgentAvailabilityInternal AgentAvailability = "internal"
+	AgentAvailabilityPrivate  AgentAvailability = "private"
+)
+
+type AgentRole string
+
+const (
+	AgentRoleOwner       AgentRole = "owner"
+	AgentRoleMaintainer  AgentRole = "maintainer"
+	AgentRoleParticipant AgentRole = "participant"
+)
+
+type AgentRoleAssignment struct {
+	AgentID    uuid.UUID
+	IdentityID uuid.UUID
+	Role       AgentRole
 }
 
 type Volume struct {
@@ -120,6 +142,7 @@ type AgentInput struct {
 	InitImage     string
 	IdleTimeout   *string
 	Capabilities  []string
+	Availability  AgentAvailability
 	Resources     ComputeResources
 }
 
@@ -134,6 +157,7 @@ type AgentUpdate struct {
 	InitImage     *string
 	IdleTimeout   *string
 	Capabilities  *[]string
+	Availability  *AgentAvailability
 	Resources     *ComputeResources
 }
 

--- a/migrations/0013_agent_availability_roles.sql
+++ b/migrations/0013_agent_availability_roles.sql
@@ -1,0 +1,16 @@
+ALTER TABLE agents
+    ADD COLUMN availability TEXT NOT NULL DEFAULT 'internal';
+
+ALTER TABLE agents
+    ADD CONSTRAINT agents_availability_check CHECK (availability IN ('internal', 'private'));
+
+CREATE TABLE agent_roles (
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    identity_id UUID NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('owner', 'maintainer', 'participant')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (agent_id, identity_id)
+);
+
+CREATE INDEX idx_agent_roles_identity ON agent_roles (identity_id);


### PR DESCRIPTION
## Summary
- Implements agent availability and per-agent roles for this repository's boundary.
- Part of the coordinated end-to-end rollout for agynio/agents#51.

## Validation
- See the tracking issue and PR comments for repo-specific test/lint results.

Closes agynio/agents#51