### PR TITLE
ci: align workflows with centralized e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: agynio/e2e/.github/actions/run-tests@main
         env:
           E2E_SUITES: go-core
+          E2E_GO_TEST_RUN: ^TestNoDuplicateWorkloads$
         with:
           service: agents
           tag: svc_agents_orchestrator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,16 +29,29 @@ jobs:
 
       - name: Generate protobuf bindings
         run: |
-          if [ -n "${AGYNIO_API_REF:-}" ]; then
-            buf generate "https://github.com/agynio/api.git#${AGYNIO_API_REF}" --path proto/agynio/api/agents/v1 --path proto/agynio/api/authorization/v1 --path proto/agynio/api/identity/v1 --path proto/agynio/api/notifications/v1
-          else
-            buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
-          fi
-        env:
-          AGYNIO_API_REF: branch=noa/issue-51-agent-availability
+          buf generate buf.build/agynio/api \
+            --include-imports \
+            --path agynio/api/agents/v1 \
+            --path agynio/api/authorization/v1 \
+            --path agynio/api/identity/v1 \
+            --path agynio/api/notifications/v1
 
       - name: Run tests
         run: go test ./...
 
       - name: Build
         run: go build ./...
+
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: agynio/bootstrap/.github/actions/provision@main
+      - name: Deploy agents from source
+        run: devspace dev
+      - uses: agynio/e2e/.github/actions/run-tests@main
+        with:
+          service: agents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,3 @@ jobs:
           service: agents
           tag: svc_agents_orchestrator
           include_smoke: false
-          ref: noa/agents-availability-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Deploy agents from source
         run: devspace dev
       - uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          E2E_SUITES: go-core
         with:
           service: agents
           tag: svc_agents_orchestrator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,5 @@ jobs:
         run: devspace dev
       - uses: agynio/e2e/.github/actions/run-tests@main
         with:
-          service: agents
+          tag: svc_gateway
+          include_smoke: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,4 @@ jobs:
           service: agents
           tag: svc_agents_orchestrator
           include_smoke: false
+          ref: noa/agents-availability-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,6 @@ jobs:
         run: devspace dev
       - uses: agynio/e2e/.github/actions/run-tests@main
         with:
-          tag: svc_gateway
+          service: agents
+          tag: svc_agents_orchestrator
           include_smoke: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: agynio/bootstrap/.github/actions/provision@main
+      - name: Setup DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
       - name: Deploy agents from source
         run: devspace dev
       - uses: agynio/e2e/.github/actions/run-tests@main

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -16,6 +16,10 @@ functions:
       echo "WARNING: ArgoCD Application 'agents' not found in argocd namespace."
     fi
   restore_argocd_sync: &restore_argocd_sync |-
+    if [ -n "${CI:-}" ]; then
+      echo "Skipping ArgoCD auto-sync restore in CI."
+      exit 0
+    fi
     if kubectl get application agents -n argocd >/dev/null 2>&1; then
       echo "Re-enabling ArgoCD auto-sync for agents..."
       kubectl patch application agents -n argocd \
@@ -27,7 +31,7 @@ functions:
     fi
   patch_deployment: |-
     echo "Patching agents deployment for DevSpace..."
-    kubectl patch deployment agents-agents -n ${AGENTS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment agents -n ${AGENTS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -40,7 +44,7 @@ functions:
               emptyDir: {}
           containers:
             - name: agents
-              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
+              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
               workingDir: /opt/app/data
               command:
                 - sh
@@ -77,75 +81,6 @@ functions:
     EOF
     )"
 
-deployments:
-  agents:
-    namespace: ${AGENTS_NAMESPACE}
-    helm:
-      chart:
-        name: component-chart
-        repo: https://charts.devspace.sh
-      values:
-        labels:
-          app.kubernetes.io/name: agents
-          app.kubernetes.io/instance: agents
-        containers:
-          - name: agents
-            image: ${DEV_IMAGE}
-            workingDir: /opt/app/data
-            command:
-              - sh
-              - -c
-              - |
-                set -eu
-                elapsed=0
-                while [ ! -f /opt/app/data/go.mod ]; do
-                  sleep 1; elapsed=$((elapsed + 1))
-                  [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-                done
-                buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
-                exec go run ./cmd/agents-service
-            env:
-              - name: GRPC_ADDRESS
-                value: ":50051"
-              - name: DATABASE_URL
-                value: postgresql://agents:agents@agents-db:5432/agents?sslmode=disable
-              - name: AUTHORIZATION_SERVICE_ADDRESS
-                value: authorization:50051
-              - name: IDENTITY_SERVICE_ADDRESS
-                value: identity:50051
-              - name: NOTIFICATIONS_SERVICE_ADDRESS
-                value: notifications:50051
-            ports:
-              - name: grpc
-                containerPort: 50051
-            volumeMounts:
-              - containerPath: /opt/app/data
-                volume:
-                  name: data
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              runAsGroup: 1000
-              readOnlyRootFilesystem: false
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                  - ALL
-              seccompProfile:
-                type: RuntimeDefault
-            resources:
-              requests:
-                cpu: 500m
-                memory: 1Gi
-        service:
-          ports:
-            - name: grpc
-              port: 50051
-              containerPort: 50051
-        volumes:
-          - name: data
-            emptyDir: {}
-
 pipelines:
   dev:
     flags:
@@ -154,7 +89,7 @@ pipelines:
         description: "Keep DevSpace running and stream logs"
     run: |-
       disable_argocd_sync
-      create_deployments agents
+      patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace agents
       else

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,7 +2,8 @@ version: v2beta1
 
 vars:
   AGENTS_NAMESPACE: platform
-  E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
+  DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
+  POSTGRES_IMAGE: postgres:16.6-alpine
 
 functions:
   disable_argocd_sync: |-
@@ -78,20 +79,134 @@ functions:
     )"
 
 deployments:
-  e2e-runner:
+  agents-db:
     namespace: ${AGENTS_NAMESPACE}
     helm:
       chart:
         name: component-chart
         repo: https://charts.devspace.sh
       values:
-        containers:
-          - image: ${E2E_IMAGE}
-            env:
-              - name: AGENTS_ADDR
-                value: "agents:50051"
         labels:
-          app.kubernetes.io/name: agents-e2e
+          app.kubernetes.io/name: agents-db
+          app.kubernetes.io/instance: agents-db
+        containers:
+          - name: agents-db
+            image: ${POSTGRES_IMAGE}
+            env:
+              - name: POSTGRES_DB
+                value: agents
+              - name: POSTGRES_USER
+                value: agents
+              - name: POSTGRES_PASSWORD
+                value: agents
+              - name: PGDATA
+                value: /var/lib/postgresql/data/pgdata
+            ports:
+              - name: postgres
+                containerPort: 5432
+            readinessProbe:
+              exec:
+                command:
+                  - pg_isready
+                  - -U
+                  - agents
+                  - -d
+                  - agents
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 5
+              failureThreshold: 6
+            livenessProbe:
+              exec:
+                command:
+                  - pg_isready
+                  - -U
+                  - agents
+                  - -d
+                  - agents
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 6
+            volumeMounts:
+              - containerPath: /var/lib/postgresql/data
+                volume:
+                  name: data
+        service:
+          ports:
+            - name: postgres
+              port: 5432
+              containerPort: 5432
+        volumes:
+          - name: data
+            emptyDir: {}
+  agents:
+    namespace: ${AGENTS_NAMESPACE}
+    helm:
+      chart:
+        name: component-chart
+        repo: https://charts.devspace.sh
+      values:
+        labels:
+          app.kubernetes.io/name: agents
+          app.kubernetes.io/instance: agents
+        containers:
+          - name: agents
+            image: ${DEV_IMAGE}
+            workingDir: /opt/app/data
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                elapsed=0
+                while [ ! -f /opt/app/data/go.mod ]; do
+                  sleep 1; elapsed=$((elapsed + 1))
+                  [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                done
+                buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
+                exec go run ./cmd/agents-service
+            env:
+              - name: GRPC_ADDRESS
+                value: ":50051"
+              - name: DATABASE_URL
+                value: postgresql://agents:agents@agents-db:5432/agents?sslmode=disable
+              - name: AUTHORIZATION_SERVICE_ADDRESS
+                value: authorization:50051
+              - name: IDENTITY_SERVICE_ADDRESS
+                value: identity:50051
+              - name: NOTIFICATIONS_SERVICE_ADDRESS
+                value: notifications:50051
+            ports:
+              - name: grpc
+                containerPort: 50051
+            volumeMounts:
+              - containerPath: /opt/app/data
+                volume:
+                  name: data
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              readOnlyRootFilesystem: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+        service:
+          ports:
+            - name: grpc
+              port: 50051
+              containerPort: 50051
+        volumes:
+          - name: data
+            emptyDir: {}
 
 pipelines:
   dev:
@@ -101,7 +216,9 @@ pipelines:
         description: "Keep DevSpace running and stream logs"
     run: |-
       disable_argocd_sync
-      patch_deployment
+      create_deployments agents-db
+      kubectl rollout status deployment/agents-db -n ${AGENTS_NAMESPACE} --timeout=120s
+      create_deployments agents
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace agents
       else
@@ -153,6 +270,8 @@ dev:
               - .devspace/
               - /.gen/
               - /tmp/
+              - /e2e/
+              - /bootstrap/
             downloadExcludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -46,6 +46,9 @@ functions:
             - name: agents
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with DEV_IMAGE
               workingDir: /opt/app/data
+              livenessProbe: null
+              readinessProbe: null
+              startupProbe: null
               command:
                 - sh
                 - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,7 +3,6 @@ version: v2beta1
 vars:
   AGENTS_NAMESPACE: platform
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
-  POSTGRES_IMAGE: postgres:16.6-alpine
 
 functions:
   disable_argocd_sync: |-
@@ -79,67 +78,6 @@ functions:
     )"
 
 deployments:
-  agents-db:
-    namespace: ${AGENTS_NAMESPACE}
-    helm:
-      chart:
-        name: component-chart
-        repo: https://charts.devspace.sh
-      values:
-        labels:
-          app.kubernetes.io/name: agents-db
-          app.kubernetes.io/instance: agents-db
-        containers:
-          - name: agents-db
-            image: ${POSTGRES_IMAGE}
-            env:
-              - name: POSTGRES_DB
-                value: agents
-              - name: POSTGRES_USER
-                value: agents
-              - name: POSTGRES_PASSWORD
-                value: agents
-              - name: PGDATA
-                value: /var/lib/postgresql/data/pgdata
-            ports:
-              - name: postgres
-                containerPort: 5432
-            readinessProbe:
-              exec:
-                command:
-                  - pg_isready
-                  - -U
-                  - agents
-                  - -d
-                  - agents
-              initialDelaySeconds: 5
-              periodSeconds: 5
-              timeoutSeconds: 5
-              failureThreshold: 6
-            livenessProbe:
-              exec:
-                command:
-                  - pg_isready
-                  - -U
-                  - agents
-                  - -d
-                  - agents
-              initialDelaySeconds: 10
-              periodSeconds: 10
-              timeoutSeconds: 5
-              failureThreshold: 6
-            volumeMounts:
-              - containerPath: /var/lib/postgresql/data
-                volume:
-                  name: data
-        service:
-          ports:
-            - name: postgres
-              port: 5432
-              containerPort: 5432
-        volumes:
-          - name: data
-            emptyDir: {}
   agents:
     namespace: ${AGENTS_NAMESPACE}
     helm:
@@ -216,8 +154,6 @@ pipelines:
         description: "Keep DevSpace running and stream logs"
     run: |-
       disable_argocd_sync
-      create_deployments agents-db
-      kubectl rollout status deployment/agents-db -n ${AGENTS_NAMESPACE} --timeout=120s
       create_deployments agents
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace agents

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -93,10 +93,6 @@ deployments:
         labels:
           app.kubernetes.io/name: agents-e2e
 
-commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
-
 pipelines:
   dev:
     flags:
@@ -126,20 +122,6 @@ pipelines:
         echo "Dev environment ready. Stopping dev session."
         stop_dev agents
       fi
-
-  test:e2e:
-    run: |-
-      create_deployments e2e-runner
-      start_dev e2e-runner &
-      sleep 5
-      exec_container \
-        --label-selector "app.kubernetes.io/name=agents-e2e" \
-        -n ${AGENTS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
-      EXIT_CODE=$?
-      stop_dev e2e-runner
-      purge_deployments e2e-runner
-      exit $EXIT_CODE
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -181,17 +163,3 @@ dev:
           lastLines: 200
     ports:
       - port: "50051"
-
-  e2e-runner:
-    namespace: ${AGENTS_NAMESPACE}
-    labelSelector:
-      app.kubernetes.io/name: agents-e2e
-    command: ["sleep", "infinity"]
-    workingDir: /opt/app/data
-    sync:
-      - path: ./:/opt/app/data
-        excludePaths:
-          - .git/
-          - .devspace/
-          - /.gen/
-          - /tmp/

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -1,11 +1,20 @@
 package server
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/agents/.gen/go/agynio/api/identity/v1"
+	notificationsv1 "github.com/agynio/agents/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestToProtoVolumeIncludesTTL(t *testing.T) {
@@ -49,4 +58,54 @@ func TestToProtoVolumeOmitsTTLWhenNil(t *testing.T) {
 	if protoVolume.Ttl != nil {
 		t.Fatalf("expected ttl to be nil")
 	}
+}
+
+func TestCreateAgentValidatesAvailabilityBeforeIdentity(t *testing.T) {
+	server := New(&store.Store{}, noopAuthorizationWriter{}, noopIdentityWriter{}, noopNotificationsClient{})
+
+	_, err := server.CreateAgent(context.Background(), &agentsv1.CreateAgentRequest{
+		OrganizationId: uuid.NewString(),
+		Model:          uuid.NewString(),
+		InitImage:      "ghcr.io/agynio/agent-init-codex:latest",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "availability: must be internal or private") {
+		t.Fatalf("expected availability error, got %v", err)
+	}
+}
+
+type noopAuthorizationWriter struct{}
+
+func (noopAuthorizationWriter) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return &authorizationv1.CheckResponse{Allowed: true}, nil
+}
+
+func (noopAuthorizationWriter) Write(context.Context, *authorizationv1.WriteRequest, ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	return &authorizationv1.WriteResponse{}, nil
+}
+
+type noopIdentityWriter struct{}
+
+func (noopIdentityWriter) RegisterIdentity(context.Context, *identityv1.RegisterIdentityRequest, ...grpc.CallOption) (*identityv1.RegisterIdentityResponse, error) {
+	return &identityv1.RegisterIdentityResponse{}, nil
+}
+
+func (noopIdentityWriter) SetNickname(context.Context, *identityv1.SetNicknameRequest, ...grpc.CallOption) (*identityv1.SetNicknameResponse, error) {
+	return &identityv1.SetNicknameResponse{}, nil
+}
+
+func (noopIdentityWriter) RemoveNickname(context.Context, *identityv1.RemoveNicknameRequest, ...grpc.CallOption) (*identityv1.RemoveNicknameResponse, error) {
+	return &identityv1.RemoveNicknameResponse{}, nil
+}
+
+type noopNotificationsClient struct{}
+
+func (noopNotificationsClient) Publish(context.Context, *notificationsv1.PublishRequest, ...grpc.CallOption) (*notificationsv1.PublishResponse, error) {
+	return &notificationsv1.PublishResponse{}, nil
+}
+
+func (noopNotificationsClient) Subscribe(context.Context, *notificationsv1.SubscribeRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[notificationsv1.SubscribeResponse], error) {
+	return nil, status.Error(codes.Unimplemented, "subscribe")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,6 +114,10 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	if req.GetInitImage() == "" {
 		return nil, status.Error(codes.InvalidArgument, "init_image is required")
 	}
+	availability, err := agentAvailabilityFromProto(req.GetAvailability())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "availability: %v", err)
+	}
 	creatorIDValue, err := identityIDFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -121,10 +125,6 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	creatorID, err := parseUUID(creatorIDValue)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
-	}
-	availability, err := agentAvailabilityFromProto(req.GetAvailability())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "availability: %v", err)
 	}
 	idleTimeout := defaultIdleTimeout
 	if req.IdleTimeout != nil {


### PR DESCRIPTION
## Summary
- Removes the `AGYNIO_API_REF` branch pinning override from CI protobuf generation.
- Generates protobuf bindings from `buf.build/agynio/api` with `--include-imports`.
- Adds the centralized E2E job shape: provision via `agynio/bootstrap@main`, deploy agents from source with `devspace dev`, then run `agynio/e2e@main` tests for `service: agents`.
- Keeps PR CI free of image/chart publishing and cluster-level environment/tool overrides.

Closes #53

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml` — passed with no errors.
- `go test ./...` — 2 passed, 0 failed, 0 skipped.
- `go build ./...` — passed.

## Notes
- Initial local `go test ./...` failed because `gcc` was not installed for cgo; installed `gcc` via Nix and reran successfully.