### PR TITLE
Fix agent organization membership authorization

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -41,7 +41,7 @@ func (s *Server) requireOrganizationMember(ctx context.Context, identityID uuid.
 
 func (s *Server) addAgentMembership(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID) error {
 	return s.writeAuthorization(ctx,
-		[]*authorizationv1.TupleKey{agentOrganizationTuple(agentID, organizationID)},
+		[]*authorizationv1.TupleKey{agentIdentityOrganizationMembershipTuple(agentID, organizationID)},
 		nil,
 	)
 }
@@ -49,13 +49,14 @@ func (s *Server) addAgentMembership(ctx context.Context, agentID uuid.UUID, orga
 func (s *Server) removeAgentMembership(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID) error {
 	return s.writeAuthorization(ctx,
 		nil,
-		[]*authorizationv1.TupleKey{agentOrganizationTuple(agentID, organizationID)},
+		[]*authorizationv1.TupleKey{agentIdentityOrganizationMembershipTuple(agentID, organizationID)},
 	)
 }
 
 func (s *Server) addAgentAuthorization(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID, creatorID uuid.UUID, availability store.AgentAvailability) error {
 	writes := []*authorizationv1.TupleKey{
 		agentOrganizationTuple(agentID, organizationID),
+		agentIdentityOrganizationMembershipTuple(agentID, organizationID),
 		agentRoleTuple(agentID, creatorID, store.AgentRoleOwner),
 	}
 	if availability == store.AgentAvailabilityInternal {
@@ -65,7 +66,10 @@ func (s *Server) addAgentAuthorization(ctx context.Context, agentID uuid.UUID, o
 }
 
 func (s *Server) removeAgentAuthorization(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID, roles []store.AgentRoleAssignment, availability store.AgentAvailability) error {
-	deletes := []*authorizationv1.TupleKey{agentOrganizationTuple(agentID, organizationID)}
+	deletes := []*authorizationv1.TupleKey{
+		agentOrganizationTuple(agentID, organizationID),
+		agentIdentityOrganizationMembershipTuple(agentID, organizationID),
+	}
 	if availability == store.AgentAvailabilityInternal {
 		deletes = append(deletes, agentInternalAccessTuple(agentID, organizationID))
 	}
@@ -112,6 +116,14 @@ func agentOrganizationTuple(agentID uuid.UUID, organizationID uuid.UUID) *author
 		User:     organizationPrefix + organizationID.String(),
 		Relation: "org",
 		Object:   agentPrefix + agentID.String(),
+	}
+}
+
+func agentIdentityOrganizationMembershipTuple(agentID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + agentID.String(),
+		Relation: "member",
+		Object:   organizationPrefix + organizationID.String(),
 	}
 }
 

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+func TestAddAgentAuthorizationWritesAgentOrganizationMembership(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	creatorID := uuid.New()
+
+	if err := server.addAgentAuthorization(context.Background(), agentID, organizationID, creatorID, store.AgentAvailabilityPrivate); err != nil {
+		t.Fatalf("add agent authorization: %v", err)
+	}
+
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), []*authorizationv1.TupleKey{
+		agentOrganizationTuple(agentID, organizationID),
+		agentIdentityOrganizationMembershipTuple(agentID, organizationID),
+		agentRoleTuple(agentID, creatorID, store.AgentRoleOwner),
+	})
+	assertTuples(t, request.GetDeletes(), nil)
+}
+
+func TestRemoveAgentAuthorizationDeletesAgentOrganizationMembership(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	ownerID := uuid.New()
+	participantID := uuid.New()
+	roles := []store.AgentRoleAssignment{
+		{AgentID: agentID, IdentityID: ownerID, Role: store.AgentRoleOwner},
+		{AgentID: agentID, IdentityID: participantID, Role: store.AgentRoleParticipant},
+	}
+
+	if err := server.removeAgentAuthorization(context.Background(), agentID, organizationID, roles, store.AgentAvailabilityPrivate); err != nil {
+		t.Fatalf("remove agent authorization: %v", err)
+	}
+
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), nil)
+	assertTuples(t, request.GetDeletes(), []*authorizationv1.TupleKey{
+		agentOrganizationTuple(agentID, organizationID),
+		agentIdentityOrganizationMembershipTuple(agentID, organizationID),
+		agentRoleTuple(agentID, ownerID, store.AgentRoleOwner),
+		agentRoleTuple(agentID, participantID, store.AgentRoleParticipant),
+	})
+}
+
+func TestRestoreAgentAuthorizationWritesAgentOrganizationMembership(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	agentID := uuid.New()
+	organizationID := uuid.New()
+	ownerID := uuid.New()
+	agent := store.Agent{
+		Meta: store.EntityMeta{
+			ID:        agentID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		OrganizationID: organizationID,
+		Availability:   store.AgentAvailabilityInternal,
+	}
+	roles := []store.AgentRoleAssignment{{AgentID: agentID, IdentityID: ownerID, Role: store.AgentRoleOwner}}
+
+	if err := server.restoreAgentAuthorization(context.Background(), agent, roles); err != nil {
+		t.Fatalf("restore agent authorization: %v", err)
+	}
+
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), []*authorizationv1.TupleKey{
+		agentOrganizationTuple(agentID, organizationID),
+		agentIdentityOrganizationMembershipTuple(agentID, organizationID),
+		agentInternalAccessTuple(agentID, organizationID),
+		agentRoleTuple(agentID, ownerID, store.AgentRoleOwner),
+	})
+	assertTuples(t, request.GetDeletes(), nil)
+}
+
+type recordingAuthorizationWriter struct {
+	writes []*authorizationv1.WriteRequest
+}
+
+func (w *recordingAuthorizationWriter) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return &authorizationv1.CheckResponse{Allowed: true}, nil
+}
+
+func (w *recordingAuthorizationWriter) Write(_ context.Context, req *authorizationv1.WriteRequest, _ ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	w.writes = append(w.writes, req)
+	return &authorizationv1.WriteResponse{}, nil
+}
+
+func singleWriteRequest(t *testing.T, authz *recordingAuthorizationWriter) *authorizationv1.WriteRequest {
+	t.Helper()
+	if len(authz.writes) != 1 {
+		t.Fatalf("expected 1 authorization write, got %d", len(authz.writes))
+	}
+	return authz.writes[0]
+}
+
+func assertTuples(t *testing.T, actual []*authorizationv1.TupleKey, expected []*authorizationv1.TupleKey) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("expected %d tuples, got %d: %#v", len(expected), len(actual), actual)
+	}
+	for i := range expected {
+		if actual[i].GetUser() != expected[i].GetUser() || actual[i].GetRelation() != expected[i].GetRelation() || actual[i].GetObject() != expected[i].GetObject() {
+			t.Fatalf("tuple %d mismatch: expected user=%q relation=%q object=%q, got user=%q relation=%q object=%q",
+				i,
+				expected[i].GetUser(),
+				expected[i].GetRelation(),
+				expected[i].GetObject(),
+				actual[i].GetUser(),
+				actual[i].GetRelation(),
+				actual[i].GetObject(),
+			)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -392,7 +392,10 @@ func (s *Server) DeleteAgent(ctx context.Context, req *agentsv1.DeleteAgentReque
 }
 
 func (s *Server) restoreAgentAuthorization(ctx context.Context, agent store.Agent, roles []store.AgentRoleAssignment) error {
-	writes := []*authorizationv1.TupleKey{agentOrganizationTuple(agent.Meta.ID, agent.OrganizationID)}
+	writes := []*authorizationv1.TupleKey{
+		agentOrganizationTuple(agent.Meta.ID, agent.OrganizationID),
+		agentIdentityOrganizationMembershipTuple(agent.Meta.ID, agent.OrganizationID),
+	}
 	if agent.Availability == store.AgentAvailabilityInternal {
 		writes = append(writes, agentInternalAccessTuple(agent.Meta.ID, agent.OrganizationID))
 	}


### PR DESCRIPTION
## Summary
- write `identity:<agent_id> member organization:<org_id>` when creating agent authorization
- delete the agent identity organization membership tuple during agent deletion
- restore the membership tuple when delete rollback restores authorization
- add unit tests for tuple write, delete, and restore behavior

Closes #55

## Test & Lint Summary
- `go test ./internal/server -run 'Test(Add|Remove|Restore)AgentAuthorization' -count=1`: internal/server passed
- `go test ./...`: internal/server passed; 5 packages had no test files
- `go vet ./...`: passed with no errors
- `go build ./...`: passed