### PR TITLE
ci: add dedicated E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,24 +41,3 @@ jobs:
 
       - name: Build
         run: go build ./...
-
-  e2e:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: agynio/bootstrap/.github/actions/provision@main
-      - name: Setup DevSpace
-        uses: agynio/e2e/.github/actions/setup-devspace@main
-      - name: Deploy agents from source
-        run: devspace dev
-      - uses: agynio/e2e/.github/actions/run-tests@main
-        env:
-          E2E_SUITES: go-core
-          E2E_GO_TEST_RUN: ^TestNoDuplicateWorkloads$
-        with:
-          service: agents
-          tag: svc_agents_orchestrator
-          include_smoke: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Provision cluster
+        uses: agynio/bootstrap/.github/actions/provision@main
+
+      - name: Setup DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
+
+      - name: Deploy agents from source
+        run: devspace dev
+
+      - name: Run E2E tests
+        uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          E2E_SUITES: go-core
+          E2E_GO_TEST_RUN: ^TestNoDuplicateWorkloads$
+        with:
+          service: agents
+          tag: svc_agents_orchestrator
+          include_smoke: false


### PR DESCRIPTION
## Summary

- Adds a dedicated `.github/workflows/e2e.yml` for the existing agents E2E job.
- Removes the E2E job from `.github/workflows/ci.yml` so CI and E2E have separate workflow badge targets.
- Preserves the current E2E suite, test filter, service, and tag settings.

Closes #57

## Test & Lint Summary

Commands run:

```bash
buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1
go test ./...
git diff --check
actionlint .github/workflows/ci.yml .github/workflows/e2e.yml
```

Results:

- Go tests: 1 package passed; 0 failed; 0 skipped.
- Workflow linting: passed with no errors.
- Whitespace validation: passed.