### PR TITLE
fix(chart): default agents platform wiring

### DIFF
--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -1,5 +1,5 @@
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: agents
 
 global:
   imageRegistry: ""
@@ -73,7 +73,10 @@ env:
   - name: GRPC_ADDRESS
     value: ":50051"
   - name: DATABASE_URL
-    value: ""
+    valueFrom:
+      secretKeyRef:
+        name: agyn-platform-database-urls
+        key: agents
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""


### PR DESCRIPTION
## Summary

Part of agynio/platform-charts#4.

- Sets the chart-owned stable fullname default to `agents`.
- Defaults `DATABASE_URL` to the platform database Secret convention: `agyn-platform-database-urls` key `agents`.
- Keeps generated Helm dependency artifacts out of the commit.

## Validation

```sh
helm dependency build charts/agents
helm lint charts/agents
helm template test charts/agents >/tmp/agents-chart.yaml
```

Results:

- Helm lint: 1 chart linted, 0 failed.
- Helm template: rendered successfully.