### PR TITLE
feat: add sandbox resource foundation

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -15,6 +15,7 @@ const (
 	identityPrefix     = "identity:"
 	organizationPrefix = "organization:"
 	agentPrefix        = "agent:"
+	sandboxPrefix      = "sandbox:"
 )
 
 type AuthorizationWriter interface {
@@ -35,6 +36,40 @@ func (s *Server) requireOrganizationMember(ctx context.Context, identityID uuid.
 	}
 	if !response.GetAllowed() {
 		return status.Error(codes.InvalidArgument, "identity is not a member of the agent organization")
+	}
+	return nil
+}
+
+func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) error {
+	response, err := s.authz.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     identityPrefix + identityID.String(),
+			Relation: relation,
+			Object:   organizationPrefix + organizationID.String(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if !response.GetAllowed() {
+		return status.Errorf(codes.PermissionDenied, "identity lacks %s on organization", relation)
+	}
+	return nil
+}
+
+func (s *Server) requireSandboxRelation(ctx context.Context, identityID uuid.UUID, sandboxID uuid.UUID, relation string) error {
+	response, err := s.authz.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     identityPrefix + identityID.String(),
+			Relation: relation,
+			Object:   sandboxPrefix + sandboxID.String(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if !response.GetAllowed() {
+		return status.Errorf(codes.PermissionDenied, "identity lacks %s on sandbox", relation)
 	}
 	return nil
 }
@@ -103,6 +138,20 @@ func (s *Server) removeAgentRoleAuthorization(ctx context.Context, agentID uuid.
 	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{agentRoleTuple(agentID, identityID, role)})
 }
 
+func (s *Server) addSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID) error {
+	return s.writeAuthorization(ctx, []*authorizationv1.TupleKey{
+		sandboxOrganizationTuple(sandboxID, organizationID),
+		sandboxOwnerTuple(sandboxID, ownerID),
+	}, nil)
+}
+
+func (s *Server) removeSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID) error {
+	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{
+		sandboxOrganizationTuple(sandboxID, organizationID),
+		sandboxOwnerTuple(sandboxID, ownerID),
+	})
+}
+
 func (s *Server) writeAuthorization(ctx context.Context, writes []*authorizationv1.TupleKey, deletes []*authorizationv1.TupleKey) error {
 	_, err := s.authz.Write(ctx, &authorizationv1.WriteRequest{
 		Writes:  writes,
@@ -140,5 +189,21 @@ func agentRoleTuple(agentID uuid.UUID, identityID uuid.UUID, role store.AgentRol
 		User:     identityPrefix + identityID.String(),
 		Relation: string(role),
 		Object:   agentPrefix + agentID.String(),
+	}
+}
+
+func sandboxOrganizationTuple(sandboxID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     organizationPrefix + organizationID.String(),
+		Relation: "org",
+		Object:   sandboxPrefix + sandboxID.String(),
+	}
+}
+
+func sandboxOwnerTuple(sandboxID uuid.UUID, ownerID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + ownerID.String(),
+		Relation: "owner",
+		Object:   sandboxPrefix + sandboxID.String(),
 	}
 }

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
 	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
 	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
@@ -88,11 +89,107 @@ func TestRestoreAgentAuthorizationWritesAgentOrganizationMembership(t *testing.T
 	assertTuples(t, request.GetDeletes(), nil)
 }
 
-type recordingAuthorizationWriter struct {
-	writes []*authorizationv1.WriteRequest
+func TestAddSandboxAuthorizationWritesOrgAndOwner(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	sandboxID := uuid.New()
+	organizationID := uuid.New()
+	ownerID := uuid.New()
+
+	if err := server.addSandboxAuthorization(context.Background(), sandboxID, organizationID, ownerID); err != nil {
+		t.Fatalf("add sandbox authorization: %v", err)
+	}
+
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), []*authorizationv1.TupleKey{
+		sandboxOrganizationTuple(sandboxID, organizationID),
+		sandboxOwnerTuple(sandboxID, ownerID),
+	})
+	assertTuples(t, request.GetDeletes(), nil)
 }
 
-func (w *recordingAuthorizationWriter) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+func TestRemoveSandboxAuthorizationDeletesOrgAndOwner(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	sandboxID := uuid.New()
+	organizationID := uuid.New()
+	ownerID := uuid.New()
+
+	if err := server.removeSandboxAuthorization(context.Background(), sandboxID, organizationID, ownerID); err != nil {
+		t.Fatalf("remove sandbox authorization: %v", err)
+	}
+
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), nil)
+	assertTuples(t, request.GetDeletes(), []*authorizationv1.TupleKey{
+		sandboxOrganizationTuple(sandboxID, organizationID),
+		sandboxOwnerTuple(sandboxID, ownerID),
+	})
+}
+
+func TestSandboxListFilterDefaultsToCallerOwner(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	organizationID := uuid.New()
+	identityID := uuid.New()
+
+	filter, err := server.sandboxListFilter(context.Background(), &agentsv1.ListSandboxesRequest{}, organizationID, identityID)
+	if err != nil {
+		t.Fatalf("sandbox list filter: %v", err)
+	}
+	if filter.OwnerID == nil || *filter.OwnerID != identityID {
+		t.Fatalf("expected default owner filter %s, got %v", identityID, filter.OwnerID)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "member"),
+	})
+}
+
+func TestSandboxListFilterAllowsOrgWideListAll(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	allOwners := ""
+
+	filter, err := server.sandboxListFilter(context.Background(), &agentsv1.ListSandboxesRequest{OwnerId: &allOwners}, organizationID, identityID)
+	if err != nil {
+		t.Fatalf("sandbox list filter: %v", err)
+	}
+	if filter.OwnerID != nil {
+		t.Fatalf("expected no owner filter for list-all, got %v", filter.OwnerID)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "can_list_sandboxes"),
+	})
+}
+
+func TestSandboxListFilterRequiresListPermissionForOtherOwner(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	otherOwnerID := uuid.NewString()
+
+	filter, err := server.sandboxListFilter(context.Background(), &agentsv1.ListSandboxesRequest{OwnerId: &otherOwnerID}, organizationID, identityID)
+	if err != nil {
+		t.Fatalf("sandbox list filter: %v", err)
+	}
+	if filter.OwnerID == nil || filter.OwnerID.String() != otherOwnerID {
+		t.Fatalf("expected owner filter %s, got %v", otherOwnerID, filter.OwnerID)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "can_list_sandboxes"),
+	})
+}
+
+type recordingAuthorizationWriter struct {
+	writes []*authorizationv1.WriteRequest
+	checks []*authorizationv1.CheckRequest
+}
+
+func (w *recordingAuthorizationWriter) Check(_ context.Context, req *authorizationv1.CheckRequest, _ ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	w.checks = append(w.checks, req)
 	return &authorizationv1.CheckResponse{Allowed: true}, nil
 }
 
@@ -126,5 +223,34 @@ func assertTuples(t *testing.T, actual []*authorizationv1.TupleKey, expected []*
 				actual[i].GetObject(),
 			)
 		}
+	}
+}
+
+func assertChecks(t *testing.T, actual []*authorizationv1.CheckRequest, expected []*authorizationv1.TupleKey) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("expected %d checks, got %d: %#v", len(expected), len(actual), actual)
+	}
+	for i := range expected {
+		actualTuple := actual[i].GetTupleKey()
+		if actualTuple.GetUser() != expected[i].GetUser() || actualTuple.GetRelation() != expected[i].GetRelation() || actualTuple.GetObject() != expected[i].GetObject() {
+			t.Fatalf("check %d mismatch: expected user=%q relation=%q object=%q, got user=%q relation=%q object=%q",
+				i,
+				expected[i].GetUser(),
+				expected[i].GetRelation(),
+				expected[i].GetObject(),
+				actualTuple.GetUser(),
+				actualTuple.GetRelation(),
+				actualTuple.GetObject(),
+			)
+		}
+	}
+}
+
+func organizationRelationTuple(identityID uuid.UUID, organizationID uuid.UUID, relation string) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + identityID.String(),
+		Relation: relation,
+		Object:   organizationPrefix + organizationID.String(),
 	}
 }

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -108,6 +108,39 @@ func toProtoImagePullSecretAttachment(attachment store.ImagePullSecretAttachment
 	panic("image pull secret attachment missing target")
 }
 
+func toProtoEnvironment(environment store.Environment) *agentsv1.Environment {
+	return &agentsv1.Environment{
+		Meta:           toProtoEntityMeta(environment.Meta),
+		OrganizationId: environment.OrganizationID.String(),
+		Name:           environment.Name,
+		FlavorId:       environment.FlavorID.String(),
+		Image:          environment.Image,
+		FlavorName:     environment.FlavorName,
+	}
+}
+
+func toProtoSandbox(sandbox store.Sandbox) *agentsv1.Sandbox {
+	protoSandbox := &agentsv1.Sandbox{
+		Meta:            toProtoEntityMeta(sandbox.Meta),
+		OrganizationId:  sandbox.OrganizationID.String(),
+		Name:            sandbox.Name,
+		EnvironmentId:   sandbox.EnvironmentID.String(),
+		OwnerId:         sandbox.OwnerID.String(),
+		Status:          sandboxStatusToProto(sandbox.Status),
+		IdleTimeout:     sandbox.IdleTimeout,
+		Ttl:             sandbox.TTL,
+		EnvironmentName: sandbox.EnvironmentName,
+	}
+	if sandbox.LastSessionAt != nil {
+		protoSandbox.LastSessionAt = timestamppb.New(*sandbox.LastSessionAt)
+	}
+	if sandbox.WorkloadID != nil {
+		workloadID := sandbox.WorkloadID.String()
+		protoSandbox.WorkloadId = &workloadID
+	}
+	return protoSandbox
+}
+
 func toProtoMcp(mcp store.Mcp) *agentsv1.Mcp {
 	return &agentsv1.Mcp{
 		Meta:        toProtoEntityMeta(mcp.Meta),

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +59,124 @@ func TestToProtoVolumeOmitsTTLWhenNil(t *testing.T) {
 	protoVolume := toProtoVolume(volume)
 	if protoVolume.Ttl != nil {
 		t.Fatalf("expected ttl to be nil")
+	}
+}
+
+func TestValidateSandboxName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "brave-otter"},
+		{name: "sandbox1"},
+		{name: "", wantErr: true},
+		{name: "Brave", wantErr: true},
+		{name: "brave_otter", wantErr: true},
+		{name: strings.Repeat("a", 64), wantErr: true},
+	}
+
+	for _, test := range tests {
+		err := validateSandboxName(test.name)
+		if (err != nil) != test.wantErr {
+			t.Fatalf("validateSandboxName(%q) error = %v, wantErr %v", test.name, err, test.wantErr)
+		}
+	}
+}
+
+func TestGenerateSandboxNameMatchesPattern(t *testing.T) {
+	name, err := generateSandboxNameWithReader(bytes.NewReader([]byte{0, 0, 0xaa, 0xbb, 0xcc, 0xdd}))
+	if err != nil {
+		t.Fatalf("generate sandbox name: %v", err)
+	}
+	if err := validateSandboxName(name); err != nil {
+		t.Fatalf("generated name %q failed validation: %v", name, err)
+	}
+	if !strings.HasSuffix(name, "-aabbccdd") {
+		t.Fatalf("expected hex suffix, got %q", name)
+	}
+}
+
+func TestCreateSandboxWithGeneratedNameRetriesCollisions(t *testing.T) {
+	created := 0
+	generated := []string{"brave-otter-00000001", "brave-otter-00000002"}
+	generate := func() (string, error) {
+		name := generated[created]
+		created++
+		return name, nil
+	}
+	create := func(name string) (store.Sandbox, error) {
+		if name == generated[0] {
+			return store.Sandbox{}, store.AlreadyExists("sandbox")
+		}
+		return store.Sandbox{Name: name}, nil
+	}
+
+	sandbox, err := createSandboxWithGeneratedName(2, generate, create)
+	if err != nil {
+		t.Fatalf("create sandbox with generated name: %v", err)
+	}
+	if sandbox.Name != generated[1] {
+		t.Fatalf("expected retried generated name %q, got %q", generated[1], sandbox.Name)
+	}
+}
+
+func TestCreateSandboxWithGeneratedNameExhaustsCollisions(t *testing.T) {
+	generate := func() (string, error) { return "brave-otter-00000001", nil }
+	create := func(string) (store.Sandbox, error) { return store.Sandbox{}, store.AlreadyExists("sandbox") }
+
+	_, err := createSandboxWithGeneratedName(2, generate, create)
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("expected resource exhausted, got %v", err)
+	}
+}
+
+func TestCreateSandboxWithGeneratedNamePropagatesNonCollision(t *testing.T) {
+	wantErr := fmt.Errorf("store failed")
+	generate := func() (string, error) { return "brave-otter-00000001", nil }
+	create := func(string) (store.Sandbox, error) { return store.Sandbox{}, wantErr }
+
+	_, err := createSandboxWithGeneratedName(2, generate, create)
+	if err != wantErr {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestToProtoSandboxIncludesFoundationFields(t *testing.T) {
+	lastSessionAt := time.Now().UTC()
+	workloadID := uuid.New()
+	sandbox := store.Sandbox{
+		Meta: store.EntityMeta{
+			ID:        uuid.New(),
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		OrganizationID:  uuid.New(),
+		Name:            "brave-otter",
+		EnvironmentID:   uuid.New(),
+		OwnerID:         uuid.New(),
+		Status:          store.SandboxStatusRunning,
+		IdleTimeout:     "30m",
+		TTL:             "72h",
+		LastSessionAt:   &lastSessionAt,
+		EnvironmentName: "default",
+		WorkloadID:      &workloadID,
+	}
+
+	protoSandbox := toProtoSandbox(sandbox)
+	if protoSandbox.GetName() != sandbox.Name {
+		t.Fatalf("expected name %q, got %q", sandbox.Name, protoSandbox.GetName())
+	}
+	if protoSandbox.GetStatus() != agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING {
+		t.Fatalf("expected running status, got %v", protoSandbox.GetStatus())
+	}
+	if protoSandbox.GetEnvironmentName() != sandbox.EnvironmentName {
+		t.Fatalf("expected environment name %q, got %q", sandbox.EnvironmentName, protoSandbox.GetEnvironmentName())
+	}
+	if protoSandbox.GetWorkloadId() != workloadID.String() {
+		t.Fatalf("expected workload id %q, got %q", workloadID, protoSandbox.GetWorkloadId())
+	}
+	if protoSandbox.GetLastSessionAt() == nil {
+		t.Fatalf("expected last_session_at")
 	}
 }
 

--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	notificationsv1 "github.com/agynio/agents/.gen/go/agynio/api/notifications/v1"
+	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-const agentUpdatedEvent = "agent.updated"
+const (
+	agentUpdatedEvent   = "agent.updated"
+	sandboxUpdatedEvent = "sandbox.updated"
+)
 
 func (s *Server) publishAgentUpdated(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID) {
 	payload, err := structpb.NewStruct(map[string]any{
@@ -39,6 +44,43 @@ func (s *Server) publishAgentUpdatedByID(ctx context.Context, agentID uuid.UUID)
 		return
 	}
 	s.publishAgentUpdated(ctx, agent.Meta.ID, agent.OrganizationID)
+}
+
+func (s *Server) publishSandboxUpdated(ctx context.Context, sandbox store.Sandbox) {
+	fields := map[string]any{
+		"sandbox_id":      sandbox.Meta.ID.String(),
+		"organization_id": sandbox.OrganizationID.String(),
+		"name":            sandbox.Name,
+		"environment_id":  sandbox.EnvironmentID.String(),
+		"owner_id":        sandbox.OwnerID.String(),
+		"status":          string(sandbox.Status),
+		"idle_timeout":    sandbox.IdleTimeout,
+		"ttl":             sandbox.TTL,
+		"last_session_at": nil,
+	}
+	if sandbox.LastSessionAt != nil {
+		fields["last_session_at"] = sandbox.LastSessionAt.UTC().Format(time.RFC3339Nano)
+	}
+	if sandbox.WorkloadID != nil {
+		fields["workload_id"] = sandbox.WorkloadID.String()
+	}
+	payload, err := structpb.NewStruct(fields)
+	if err != nil {
+		log.Printf("agents: build sandbox.updated payload: %v", err)
+		return
+	}
+	_, err = s.notifications.Publish(ctx, &notificationsv1.PublishRequest{
+		Event: sandboxUpdatedEvent,
+		Rooms: []string{
+			fmt.Sprintf("sandbox_owner:%s", sandbox.OwnerID),
+			fmt.Sprintf("sandbox_org:%s", sandbox.OrganizationID),
+		},
+		Payload: payload,
+		Source:  "agents",
+	})
+	if err != nil {
+		log.Printf("agents: publish sandbox.updated: %v", err)
+	}
 }
 
 func (s *Server) resolveAgentID(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID) (uuid.UUID, error) {

--- a/internal/server/notifications_test.go
+++ b/internal/server/notifications_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	notificationsv1 "github.com/agynio/agents/.gen/go/agynio/api/notifications/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestPublishSandboxUpdatedIncludesSnapshotPayload(t *testing.T) {
+	notifications := &recordingNotificationsClient{}
+	server := &Server{notifications: notifications}
+	lastSessionAt := time.Date(2026, 7, 16, 12, 30, 0, 123, time.UTC)
+	workloadID := uuid.New()
+	sandbox := store.Sandbox{
+		Meta: store.EntityMeta{
+			ID: uuid.New(),
+		},
+		OrganizationID: uuid.New(),
+		Name:           "brave-otter-aabbccdd",
+		EnvironmentID:  uuid.New(),
+		OwnerID:        uuid.New(),
+		Status:         store.SandboxStatusRunning,
+		IdleTimeout:    "30m",
+		TTL:            "72h",
+		LastSessionAt:  &lastSessionAt,
+		WorkloadID:     &workloadID,
+	}
+
+	server.publishSandboxUpdated(context.Background(), sandbox)
+
+	if len(notifications.published) != 1 {
+		t.Fatalf("expected 1 publish request, got %d", len(notifications.published))
+	}
+	request := notifications.published[0]
+	if request.GetEvent() != sandboxUpdatedEvent {
+		t.Fatalf("expected event %q, got %q", sandboxUpdatedEvent, request.GetEvent())
+	}
+	assertRooms(t, request.GetRooms(), []string{
+		"sandbox_owner:" + sandbox.OwnerID.String(),
+		"sandbox_org:" + sandbox.OrganizationID.String(),
+	})
+	fields := request.GetPayload().GetFields()
+	assertStringField(t, fields, "sandbox_id", sandbox.Meta.ID.String())
+	assertStringField(t, fields, "organization_id", sandbox.OrganizationID.String())
+	assertStringField(t, fields, "name", sandbox.Name)
+	assertStringField(t, fields, "environment_id", sandbox.EnvironmentID.String())
+	assertStringField(t, fields, "owner_id", sandbox.OwnerID.String())
+	assertStringField(t, fields, "status", string(sandbox.Status))
+	assertStringField(t, fields, "idle_timeout", sandbox.IdleTimeout)
+	assertStringField(t, fields, "ttl", sandbox.TTL)
+	assertStringField(t, fields, "last_session_at", lastSessionAt.Format(time.RFC3339Nano))
+	assertStringField(t, fields, "workload_id", workloadID.String())
+}
+
+func TestPublishSandboxUpdatedUsesNullOptionalPayloadFields(t *testing.T) {
+	notifications := &recordingNotificationsClient{}
+	server := &Server{notifications: notifications}
+	sandbox := store.Sandbox{
+		Meta: store.EntityMeta{
+			ID: uuid.New(),
+		},
+		OrganizationID: uuid.New(),
+		Name:           "brave-otter-aabbccdd",
+		EnvironmentID:  uuid.New(),
+		OwnerID:        uuid.New(),
+		Status:         store.SandboxStatusStarting,
+		IdleTimeout:    "30m",
+		TTL:            "72h",
+	}
+
+	server.publishSandboxUpdated(context.Background(), sandbox)
+
+	fields := notifications.published[0].GetPayload().GetFields()
+	if _, ok := fields["workload_id"]; ok {
+		t.Fatalf("expected workload_id to be omitted")
+	}
+	if fields["last_session_at"].GetNullValue() != 0 {
+		t.Fatalf("expected last_session_at null, got %v", fields["last_session_at"])
+	}
+}
+
+type recordingNotificationsClient struct {
+	published []*notificationsv1.PublishRequest
+}
+
+func (c *recordingNotificationsClient) Publish(_ context.Context, req *notificationsv1.PublishRequest, _ ...grpc.CallOption) (*notificationsv1.PublishResponse, error) {
+	c.published = append(c.published, req)
+	return &notificationsv1.PublishResponse{}, nil
+}
+
+func (c *recordingNotificationsClient) Subscribe(context.Context, *notificationsv1.SubscribeRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[notificationsv1.SubscribeResponse], error) {
+	return nil, status.Error(codes.Unimplemented, "subscribe")
+}
+
+func assertStringField(t *testing.T, fields map[string]*structpb.Value, name string, expected string) {
+	t.Helper()
+	field, ok := fields[name]
+	if !ok {
+		t.Fatalf("expected payload field %q", name)
+	}
+	if field.GetStringValue() != expected {
+		t.Fatalf("expected field %q to be %q, got %q", name, expected, field.GetStringValue())
+	}
+}
+
+func assertRooms(t *testing.T, actual []string, expected []string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("expected %d rooms, got %d", len(expected), len(actual))
+	}
+	for index := range expected {
+		if actual[index] != expected[index] {
+			t.Fatalf("room %d: expected %q, got %q", index, expected[index], actual[index])
+		}
+	}
+}

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -1,0 +1,512 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"regexp"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	maxSandboxNameLength      = 63
+	defaultSandboxIdleTimeout = "30m"
+	defaultSandboxTTL         = "72h"
+	maxGeneratedNameAttempts  = 8
+)
+
+var (
+	sandboxNamePattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+	sandboxAdjectives  = []string{"brave", "calm", "eager", "gentle", "lucky", "nimble", "quiet", "rapid"}
+	sandboxNouns       = []string{"badger", "falcon", "otter", "panda", "raven", "tiger", "yak", "zebra"}
+)
+
+func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvironmentRequest) (*agentsv1.CreateEnvironmentResponse, error) {
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	flavorID, err := parseUUID(req.GetFlavorId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "flavor_id: %v", err)
+	}
+	if err := validateSandboxName(req.GetName()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+	}
+	if req.GetImage() == "" {
+		return nil, status.Error(codes.InvalidArgument, "image is required")
+	}
+	environment, err := s.store.CreateEnvironment(ctx, organizationID, store.EnvironmentInput{
+		Name:     req.GetName(),
+		FlavorID: flavorID,
+		Image:    req.GetImage(),
+	})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &agentsv1.CreateEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
+}
+
+func (s *Server) GetEnvironment(ctx context.Context, req *agentsv1.GetEnvironmentRequest) (*agentsv1.GetEnvironmentResponse, error) {
+	id, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	environment, err := s.store.GetEnvironment(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &agentsv1.GetEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
+}
+
+func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvironmentRequest) (*agentsv1.UpdateEnvironmentResponse, error) {
+	id, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	if req.Name == nil && req.FlavorId == nil && req.Image == nil {
+		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+	update := store.EnvironmentUpdate{}
+	if req.Name != nil {
+		name := req.GetName()
+		if err := validateSandboxName(name); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+		}
+		update.Name = &name
+	}
+	if req.FlavorId != nil {
+		flavorID, err := parseUUID(req.GetFlavorId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "flavor_id: %v", err)
+		}
+		update.FlavorID = &flavorID
+	}
+	if req.Image != nil {
+		image := req.GetImage()
+		if image == "" {
+			return nil, status.Error(codes.InvalidArgument, "image is required")
+		}
+		update.Image = &image
+	}
+	environment, err := s.store.UpdateEnvironment(ctx, id, update)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &agentsv1.UpdateEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
+}
+
+func (s *Server) DeleteEnvironment(ctx context.Context, req *agentsv1.DeleteEnvironmentRequest) (*agentsv1.DeleteEnvironmentResponse, error) {
+	id, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	if err := s.store.DeleteEnvironment(ctx, id); err != nil {
+		return nil, toStatusError(err)
+	}
+	return &agentsv1.DeleteEnvironmentResponse{}, nil
+}
+
+func (s *Server) ListEnvironments(ctx context.Context, req *agentsv1.ListEnvironmentsRequest) (*agentsv1.ListEnvironmentsResponse, error) {
+	cursor, err := decodePageCursor(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+	}
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	result, err := s.store.ListEnvironments(ctx, organizationID, store.EnvironmentFilter{}, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	environments, nextToken := mapListResult(result.Environments, result.NextCursor, toProtoEnvironment)
+	return &agentsv1.ListEnvironmentsResponse{Environments: environments, NextPageToken: nextToken}, nil
+}
+
+func (s *Server) CreateSandbox(ctx context.Context, req *agentsv1.CreateSandboxRequest) (*agentsv1.CreateSandboxResponse, error) {
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	environmentID, err := parseUUID(req.GetEnvironmentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+	}
+	var requestedName *string
+	if req.Name != nil {
+		name := req.GetName()
+		if err := validateSandboxName(name); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+		}
+		requestedName = &name
+	}
+	if err := validateDurationString(defaultSandboxIdleTimeout); err != nil {
+		return nil, status.Errorf(codes.Internal, "default sandbox idle_timeout: %v", err)
+	}
+	if err := validateDurationString(defaultSandboxTTL); err != nil {
+		return nil, status.Errorf(codes.Internal, "default sandbox ttl: %v", err)
+	}
+	ownerID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrganizationRelation(ctx, ownerID, organizationID, "can_create_sandbox"); err != nil {
+		return nil, err
+	}
+
+	var sandbox store.Sandbox
+	if requestedName != nil {
+		sandbox, err = s.store.CreateSandbox(ctx, organizationID, store.SandboxInput{
+			Name:          *requestedName,
+			EnvironmentID: environmentID,
+			OwnerID:       ownerID,
+			Status:        store.SandboxStatusStarting,
+			IdleTimeout:   defaultSandboxIdleTimeout,
+			TTL:           defaultSandboxTTL,
+		})
+	} else {
+		sandbox, err = s.createSandboxWithGeneratedName(ctx, organizationID, environmentID, ownerID)
+	}
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.addSandboxAuthorization(ctx, sandbox.Meta.ID, sandbox.OrganizationID, sandbox.OwnerID); err != nil {
+		if rollbackErr := s.store.DeleteSandboxRecord(ctx, sandbox.Meta.ID); rollbackErr != nil {
+			return nil, status.Errorf(codes.Internal, "authorization failed: %v; rollback failed: %v", err, rollbackErr)
+		}
+		return nil, err
+	}
+	s.publishSandboxUpdated(ctx, sandbox)
+	return &agentsv1.CreateSandboxResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) GetSandbox(ctx context.Context, req *agentsv1.GetSandboxRequest) (*agentsv1.GetSandboxResponse, error) {
+	sandbox, err := s.getSandboxFromRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if sandbox.OwnerID != identityID {
+		if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, "can_list_all"); err != nil {
+			return nil, err
+		}
+	}
+	return &agentsv1.GetSandboxResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) ListSandboxes(ctx context.Context, req *agentsv1.ListSandboxesRequest) (*agentsv1.ListSandboxesResponse, error) {
+	cursor, err := decodePageCursor(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+	}
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filter, err := s.sandboxListFilter(ctx, req, organizationID, identityID)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.store.ListSandboxes(ctx, organizationID, filter, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	sandboxes, nextToken := mapListResult(result.Sandboxes, result.NextCursor, toProtoSandbox)
+	return &agentsv1.ListSandboxesResponse{Sandboxes: sandboxes, NextPageToken: nextToken}, nil
+}
+
+func (s *Server) sandboxListFilter(ctx context.Context, req *agentsv1.ListSandboxesRequest, organizationID uuid.UUID, identityID uuid.UUID) (store.SandboxFilter, error) {
+	filter := store.SandboxFilter{IncludeTerminated: req.GetIncludeTerminated()}
+	if req.OwnerId == nil {
+		filter.OwnerID = &identityID
+		if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
+			return store.SandboxFilter{}, err
+		}
+		return filter, nil
+	}
+
+	if req.GetOwnerId() == "" {
+		if err := s.requireOrganizationRelation(ctx, identityID, organizationID, "can_list_sandboxes"); err != nil {
+			return store.SandboxFilter{}, err
+		}
+		return filter, nil
+	}
+
+	ownerID, err := parseUUID(req.GetOwnerId())
+	if err != nil {
+		return store.SandboxFilter{}, status.Errorf(codes.InvalidArgument, "owner_id: %v", err)
+	}
+	filter.OwnerID = &ownerID
+	if ownerID == identityID {
+		if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
+			return store.SandboxFilter{}, err
+		}
+		return filter, nil
+	}
+	if err := s.requireOrganizationRelation(ctx, identityID, organizationID, "can_list_sandboxes"); err != nil {
+		return store.SandboxFilter{}, err
+	}
+	return filter, nil
+}
+
+func (s *Server) StopSandbox(ctx context.Context, req *agentsv1.StopSandboxRequest) (*agentsv1.StopSandboxResponse, error) {
+	sandbox, err := s.updateSandboxStatusWithAuthorization(ctx, req.GetId(), "can_stop", store.SandboxStatusStopped)
+	if err != nil {
+		return nil, err
+	}
+	return &agentsv1.StopSandboxResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) DeleteSandbox(ctx context.Context, req *agentsv1.DeleteSandboxRequest) (*agentsv1.DeleteSandboxResponse, error) {
+	sandboxID, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	sandbox, err := s.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, "can_delete"); err != nil {
+		return nil, err
+	}
+	terminated := store.SandboxStatusTerminated
+	sandbox, err = s.store.UpdateSandbox(ctx, sandbox.Meta.ID, store.SandboxUpdate{Status: &terminated})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	s.publishSandboxUpdated(ctx, sandbox)
+	return &agentsv1.DeleteSandboxResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) EnsureSandboxRunning(ctx context.Context, req *agentsv1.EnsureSandboxRunningRequest) (*agentsv1.EnsureSandboxRunningResponse, error) {
+	sandboxID, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	sandbox, err := s.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, "can_connect"); err != nil {
+		return nil, err
+	}
+	if sandbox.Status == store.SandboxStatusTerminated {
+		return nil, status.Error(codes.FailedPrecondition, "terminated sandbox cannot be started")
+	}
+	if sandbox.Status == store.SandboxStatusStopped || sandbox.Status == store.SandboxStatusFailed {
+		return nil, status.Error(codes.Unimplemented, "sandbox runtime orchestration is not yet available")
+	}
+	return &agentsv1.EnsureSandboxRunningResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) UpdateSandboxLastSession(ctx context.Context, req *agentsv1.UpdateSandboxLastSessionRequest) (*agentsv1.UpdateSandboxLastSessionResponse, error) {
+	sandboxID, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	if req.GetLastSessionAt() == nil {
+		return nil, status.Error(codes.InvalidArgument, "last_session_at is required")
+	}
+	lastSessionAt := req.GetLastSessionAt().AsTime()
+	sandbox, err := s.store.UpdateSandbox(ctx, sandboxID, store.SandboxUpdate{LastSessionAt: &lastSessionAt})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	s.publishSandboxUpdated(ctx, sandbox)
+	return &agentsv1.UpdateSandboxLastSessionResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) createSandboxWithGeneratedName(ctx context.Context, organizationID uuid.UUID, environmentID uuid.UUID, ownerID uuid.UUID) (store.Sandbox, error) {
+	create := func(name string) (store.Sandbox, error) {
+		return s.store.CreateSandbox(ctx, organizationID, store.SandboxInput{
+			Name:          name,
+			EnvironmentID: environmentID,
+			OwnerID:       ownerID,
+			Status:        store.SandboxStatusStarting,
+			IdleTimeout:   defaultSandboxIdleTimeout,
+			TTL:           defaultSandboxTTL,
+		})
+	}
+	return createSandboxWithGeneratedName(maxGeneratedNameAttempts, generateSandboxName, create)
+}
+
+func createSandboxWithGeneratedName(attempts int, generate func() (string, error), create func(string) (store.Sandbox, error)) (store.Sandbox, error) {
+	for range attempts {
+		name, err := generate()
+		if err != nil {
+			return store.Sandbox{}, err
+		}
+		sandbox, err := create(name)
+		if err == nil {
+			return sandbox, nil
+		}
+		var exists *store.AlreadyExistsError
+		if !errors.As(err, &exists) {
+			return store.Sandbox{}, err
+		}
+	}
+	return store.Sandbox{}, status.Error(codes.ResourceExhausted, "unable to generate a unique sandbox name")
+}
+
+func (s *Server) getSandboxFromRequest(ctx context.Context, req *agentsv1.GetSandboxRequest) (store.Sandbox, error) {
+	switch ref := req.GetRef().(type) {
+	case *agentsv1.GetSandboxRequest_Id:
+		id, err := parseUUID(ref.Id)
+		if err != nil {
+			return store.Sandbox{}, status.Errorf(codes.InvalidArgument, "id: %v", err)
+		}
+		sandbox, err := s.store.GetSandbox(ctx, id)
+		if err != nil {
+			return store.Sandbox{}, toStatusError(err)
+		}
+		return sandbox, nil
+	case *agentsv1.GetSandboxRequest_Name:
+		if ref.Name == nil {
+			return store.Sandbox{}, status.Error(codes.InvalidArgument, "name ref must be provided")
+		}
+		organizationID, err := parseUUID(ref.Name.GetOrganizationId())
+		if err != nil {
+			return store.Sandbox{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		if err := validateSandboxName(ref.Name.GetName()); err != nil {
+			return store.Sandbox{}, status.Errorf(codes.InvalidArgument, "name: %v", err)
+		}
+		sandbox, err := s.store.GetSandboxByName(ctx, organizationID, ref.Name.GetName())
+		if err != nil {
+			return store.Sandbox{}, toStatusError(err)
+		}
+		return sandbox, nil
+	default:
+		return store.Sandbox{}, status.Error(codes.InvalidArgument, "id or name must be specified")
+	}
+}
+
+func (s *Server) updateSandboxStatusWithAuthorization(ctx context.Context, id string, relation string, next store.SandboxStatus) (store.Sandbox, error) {
+	sandboxID, err := parseUUID(id)
+	if err != nil {
+		return store.Sandbox{}, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	sandbox, err := s.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return store.Sandbox{}, toStatusError(err)
+	}
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return store.Sandbox{}, err
+	}
+	if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, relation); err != nil {
+		return store.Sandbox{}, err
+	}
+	if sandbox.Status == store.SandboxStatusTerminated {
+		return store.Sandbox{}, status.Error(codes.FailedPrecondition, "terminated sandbox cannot be updated")
+	}
+	updated, err := s.store.UpdateSandbox(ctx, sandbox.Meta.ID, store.SandboxUpdate{Status: &next})
+	if err != nil {
+		return store.Sandbox{}, toStatusError(err)
+	}
+	s.publishSandboxUpdated(ctx, updated)
+	return updated, nil
+}
+
+func identityUUIDFromContext(ctx context.Context) (uuid.UUID, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	id, err := parseUUID(identityID)
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	return id, nil
+}
+
+func validateSandboxName(name string) error {
+	if name == "" {
+		return fmt.Errorf("value is empty")
+	}
+	if len(name) > maxSandboxNameLength {
+		return fmt.Errorf("must be at most %d characters", maxSandboxNameLength)
+	}
+	if !sandboxNamePattern.MatchString(name) {
+		return fmt.Errorf("must match %s", sandboxNamePattern.String())
+	}
+	return nil
+}
+
+func generateSandboxName() (string, error) {
+	return generateSandboxNameWithReader(rand.Reader)
+}
+
+func generateSandboxNameWithReader(reader io.Reader) (string, error) {
+	adjective, err := randomSandboxWord(reader, sandboxAdjectives)
+	if err != nil {
+		return "", err
+	}
+	noun, err := randomSandboxWord(reader, sandboxNouns)
+	if err != nil {
+		return "", err
+	}
+	suffix, err := randomHexSuffix(reader)
+	if err != nil {
+		return "", err
+	}
+	return adjective + "-" + noun + "-" + suffix, nil
+}
+
+func randomSandboxWord(reader io.Reader, words []string) (string, error) {
+	index, err := rand.Int(reader, big.NewInt(int64(len(words))))
+	if err != nil {
+		return "", err
+	}
+	return words[index.Int64()], nil
+}
+
+func randomHexSuffix(reader io.Reader) (string, error) {
+	bytes := make([]byte, 4)
+	if _, err := io.ReadFull(reader, bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func sandboxStatusToProto(sandboxStatus store.SandboxStatus) agentsv1.SandboxStatus {
+	switch sandboxStatus {
+	case store.SandboxStatusStarting:
+		return agentsv1.SandboxStatus_SANDBOX_STATUS_STARTING
+	case store.SandboxStatusRunning:
+		return agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING
+	case store.SandboxStatusStopped:
+		return agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED
+	case store.SandboxStatusFailed:
+		return agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED
+	case store.SandboxStatusTerminated:
+		return agentsv1.SandboxStatus_SANDBOX_STATUS_TERMINATED
+	default:
+		panic(fmt.Sprintf("unknown sandbox status %q", sandboxStatus))
+	}
+}

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -1,0 +1,232 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func (s *Store) CreateEnvironment(ctx context.Context, organizationID uuid.UUID, input EnvironmentInput) (Environment, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`INSERT INTO environments (organization_id, name, flavor_id, image)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING %s`, environmentColumns),
+		organizationID,
+		input.Name,
+		input.FlavorID,
+		input.Image,
+	)
+	environment, err := scanEnvironment(row)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return Environment{}, AlreadyExists("environment")
+		}
+		return Environment{}, err
+	}
+	return environment, nil
+}
+
+func (s *Store) GetEnvironment(ctx context.Context, id uuid.UUID) (Environment, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM environments WHERE id = $1`, environmentColumns),
+		id,
+	)
+	environment, err := scanEnvironment(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Environment{}, NotFound("environment")
+		}
+		return Environment{}, err
+	}
+	return environment, nil
+}
+
+func (s *Store) UpdateEnvironment(ctx context.Context, id uuid.UUID, update EnvironmentUpdate) (Environment, error) {
+	builder := updateBuilder{}
+	if update.Name != nil {
+		builder.add("name", *update.Name)
+	}
+	if update.FlavorID != nil {
+		builder.add("flavor_id", *update.FlavorID)
+	}
+	if update.Image != nil {
+		builder.add("image", *update.Image)
+	}
+	if builder.empty() {
+		return Environment{}, fmt.Errorf("environment update requires at least one field")
+	}
+
+	query, args := builder.build("environments", environmentColumns, id)
+	row := s.pool.QueryRow(ctx, query, args...)
+	environment, err := scanEnvironment(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Environment{}, NotFound("environment")
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return Environment{}, AlreadyExists("environment")
+		}
+		return Environment{}, err
+	}
+	return environment, nil
+}
+
+func (s *Store) DeleteEnvironment(ctx context.Context, id uuid.UUID) error {
+	result, err := s.pool.Exec(ctx, `DELETE FROM environments WHERE id = $1`, id)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return ForeignKeyViolation("environment")
+		}
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return NotFound("environment")
+	}
+	return nil
+}
+
+func (s *Store) ListEnvironments(ctx context.Context, organizationID uuid.UUID, _ EnvironmentFilter, pageSize int32, cursor *PageCursor) (EnvironmentListResult, error) {
+	environments, nextCursor, err := listEntities(ctx, s.pool,
+		fmt.Sprintf("SELECT %s FROM environments", environmentColumns),
+		[]string{"organization_id = $1"},
+		[]any{organizationID},
+		cursor,
+		pageSize,
+		scanEnvironment,
+		func(environment Environment) uuid.UUID { return environment.Meta.ID },
+	)
+	if err != nil {
+		return EnvironmentListResult{}, err
+	}
+	return EnvironmentListResult{Environments: environments, NextCursor: nextCursor}, nil
+}
+
+func (s *Store) CreateSandbox(ctx context.Context, organizationID uuid.UUID, input SandboxInput) (Sandbox, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`INSERT INTO sandboxes (organization_id, name, environment_id, owner_id, status, idle_timeout, ttl, environment_name)
+		 SELECT $1, $2, e.id, $4, $5, $6, $7, e.name
+		 FROM environments e
+		 WHERE e.id = $3 AND e.organization_id = $1
+		 RETURNING %s`, sandboxColumns),
+		organizationID,
+		input.Name,
+		input.EnvironmentID,
+		input.OwnerID,
+		input.Status,
+		input.IdleTimeout,
+		input.TTL,
+	)
+	sandbox, err := scanSandbox(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Sandbox{}, NotFound("environment")
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return Sandbox{}, AlreadyExists("sandbox")
+		}
+		return Sandbox{}, err
+	}
+	return sandbox, nil
+}
+
+func (s *Store) GetSandbox(ctx context.Context, id uuid.UUID) (Sandbox, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM sandboxes WHERE id = $1`, sandboxColumns),
+		id,
+	)
+	sandbox, err := scanSandbox(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Sandbox{}, NotFound("sandbox")
+		}
+		return Sandbox{}, err
+	}
+	return sandbox, nil
+}
+
+func (s *Store) GetSandboxByName(ctx context.Context, organizationID uuid.UUID, name string) (Sandbox, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM sandboxes WHERE organization_id = $1 AND name = $2`, sandboxColumns),
+		organizationID,
+		name,
+	)
+	sandbox, err := scanSandbox(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Sandbox{}, NotFound("sandbox")
+		}
+		return Sandbox{}, err
+	}
+	return sandbox, nil
+}
+
+func (s *Store) UpdateSandbox(ctx context.Context, id uuid.UUID, update SandboxUpdate) (Sandbox, error) {
+	builder := updateBuilder{}
+	if update.Status != nil {
+		builder.add("status", *update.Status)
+	}
+	if update.LastSessionAt != nil {
+		builder.add("last_session_at", *update.LastSessionAt)
+	}
+	if update.WorkloadID != nil {
+		builder.add("workload_id", *update.WorkloadID)
+	}
+	if builder.empty() {
+		return Sandbox{}, fmt.Errorf("sandbox update requires at least one field")
+	}
+
+	query, args := builder.build("sandboxes", sandboxColumns, id)
+	row := s.pool.QueryRow(ctx, query, args...)
+	sandbox, err := scanSandbox(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Sandbox{}, NotFound("sandbox")
+		}
+		return Sandbox{}, err
+	}
+	return sandbox, nil
+}
+
+func (s *Store) DeleteSandboxRecord(ctx context.Context, id uuid.UUID) error {
+	result, err := s.pool.Exec(ctx, `DELETE FROM sandboxes WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return NotFound("sandbox")
+	}
+	return nil
+}
+
+func (s *Store) ListSandboxes(ctx context.Context, organizationID uuid.UUID, filter SandboxFilter, pageSize int32, cursor *PageCursor) (SandboxListResult, error) {
+	clauses := []string{"organization_id = $1"}
+	args := []any{organizationID}
+	if filter.OwnerID != nil {
+		clauses, args = appendClause(clauses, args, "owner_id = $%d", *filter.OwnerID)
+	}
+	if !filter.IncludeTerminated {
+		clauses = append(clauses, "status <> 'terminated'")
+	}
+
+	sandboxes, nextCursor, err := listEntities(ctx, s.pool,
+		fmt.Sprintf("SELECT %s FROM sandboxes", sandboxColumns),
+		clauses,
+		args,
+		cursor,
+		pageSize,
+		scanSandbox,
+		func(sandbox Sandbox) uuid.UUID { return sandbox.Meta.ID },
+	)
+	if err != nil {
+		return SandboxListResult{}, err
+	}
+	return SandboxListResult{Sandboxes: sandboxes, NextCursor: nextCursor}, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,6 +18,8 @@ const (
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, image_pull_secret_id, agent_id, mcp_id, hook_id, created_at, updated_at`
+	environmentColumns               = `id, organization_id, name, flavor_id, image, flavor_name, created_at, updated_at`
+	sandboxColumns                   = `id, organization_id, name, environment_id, owner_id, status, idle_timeout, ttl, last_session_at, environment_name, workload_id, created_at, updated_at`
 	mcpColumns                       = `id, agent_id, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, created_at, updated_at`
 	skillColumns                     = `id, agent_id, name, body, description, created_at, updated_at`
 	hookColumns                      = `id, agent_id, event, "function", image, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, created_at, updated_at`
@@ -172,6 +174,51 @@ func scanImagePullSecretAttachment(row pgx.Row) (ImagePullSecretAttachment, erro
 	attachment.McpID = uuidPtrFromPg(mcpID)
 	attachment.HookID = uuidPtrFromPg(hookID)
 	return attachment, nil
+}
+
+func scanEnvironment(row pgx.Row) (Environment, error) {
+	var environment Environment
+	if err := row.Scan(
+		&environment.Meta.ID,
+		&environment.OrganizationID,
+		&environment.Name,
+		&environment.FlavorID,
+		&environment.Image,
+		&environment.FlavorName,
+		&environment.Meta.CreatedAt,
+		&environment.Meta.UpdatedAt,
+	); err != nil {
+		return Environment{}, err
+	}
+	return environment, nil
+}
+
+func scanSandbox(row pgx.Row) (Sandbox, error) {
+	var sandbox Sandbox
+	var lastSessionAt pgtype.Timestamptz
+	var workloadID pgtype.UUID
+	if err := row.Scan(
+		&sandbox.Meta.ID,
+		&sandbox.OrganizationID,
+		&sandbox.Name,
+		&sandbox.EnvironmentID,
+		&sandbox.OwnerID,
+		&sandbox.Status,
+		&sandbox.IdleTimeout,
+		&sandbox.TTL,
+		&lastSessionAt,
+		&sandbox.EnvironmentName,
+		&workloadID,
+		&sandbox.Meta.CreatedAt,
+		&sandbox.Meta.UpdatedAt,
+	); err != nil {
+		return Sandbox{}, err
+	}
+	if lastSessionAt.Valid {
+		sandbox.LastSessionAt = &lastSessionAt.Time
+	}
+	sandbox.WorkloadID = uuidPtrFromPg(workloadID)
+	return sandbox, nil
 }
 
 func scanMcp(row pgx.Row) (Mcp, error) {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -51,6 +51,16 @@ const (
 	AgentRoleParticipant AgentRole = "participant"
 )
 
+type SandboxStatus string
+
+const (
+	SandboxStatusStarting   SandboxStatus = "starting"
+	SandboxStatusRunning    SandboxStatus = "running"
+	SandboxStatusStopped    SandboxStatus = "stopped"
+	SandboxStatusFailed     SandboxStatus = "failed"
+	SandboxStatusTerminated SandboxStatus = "terminated"
+)
+
 type AgentRoleAssignment struct {
 	AgentID    uuid.UUID
 	IdentityID uuid.UUID
@@ -120,6 +130,29 @@ type Env struct {
 	HookID      *uuid.UUID
 	Value       *string
 	SecretID    *uuid.UUID
+}
+
+type Environment struct {
+	Meta           EntityMeta
+	OrganizationID uuid.UUID
+	Name           string
+	FlavorID       uuid.UUID
+	Image          string
+	FlavorName     string
+}
+
+type Sandbox struct {
+	Meta            EntityMeta
+	OrganizationID  uuid.UUID
+	Name            string
+	EnvironmentID   uuid.UUID
+	OwnerID         uuid.UUID
+	Status          SandboxStatus
+	IdleTimeout     string
+	TTL             string
+	LastSessionAt   *time.Time
+	EnvironmentName string
+	WorkloadID      *uuid.UUID
 }
 
 type InitScript struct {
@@ -267,6 +300,33 @@ type InitScriptUpdate struct {
 	Description *string
 }
 
+type EnvironmentInput struct {
+	Name     string
+	FlavorID uuid.UUID
+	Image    string
+}
+
+type EnvironmentUpdate struct {
+	Name     *string
+	FlavorID *uuid.UUID
+	Image    *string
+}
+
+type SandboxInput struct {
+	Name          string
+	EnvironmentID uuid.UUID
+	OwnerID       uuid.UUID
+	Status        SandboxStatus
+	IdleTimeout   string
+	TTL           string
+}
+
+type SandboxUpdate struct {
+	Status        *SandboxStatus
+	LastSessionAt *time.Time
+	WorkloadID    *uuid.UUID
+}
+
 type AgentFilter struct{}
 
 type VolumeFilter struct{}
@@ -307,6 +367,13 @@ type InitScriptFilter struct {
 	AgentID *uuid.UUID
 	McpID   *uuid.UUID
 	HookID  *uuid.UUID
+}
+
+type EnvironmentFilter struct{}
+
+type SandboxFilter struct {
+	OwnerID           *uuid.UUID
+	IncludeTerminated bool
 }
 
 type PageCursor struct {
@@ -356,4 +423,14 @@ type EnvListResult struct {
 type InitScriptListResult struct {
 	InitScripts []InitScript
 	NextCursor  *PageCursor
+}
+
+type EnvironmentListResult struct {
+	Environments []Environment
+	NextCursor   *PageCursor
+}
+
+type SandboxListResult struct {
+	Sandboxes  []Sandbox
+	NextCursor *PageCursor
 }

--- a/migrations/0014_sandbox_foundation.sql
+++ b/migrations/0014_sandbox_foundation.sql
@@ -1,0 +1,36 @@
+CREATE TABLE environments (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL,
+    name TEXT NOT NULL,
+    flavor_id UUID NOT NULL,
+    image TEXT NOT NULL,
+    flavor_name TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, name),
+    UNIQUE (organization_id, id)
+);
+
+CREATE INDEX idx_environments_organization ON environments (organization_id);
+
+CREATE TABLE sandboxes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL,
+    name TEXT NOT NULL,
+    environment_id UUID NOT NULL,
+    owner_id UUID NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('starting', 'running', 'stopped', 'failed', 'terminated')),
+    idle_timeout TEXT NOT NULL,
+    ttl TEXT NOT NULL,
+    last_session_at TIMESTAMPTZ,
+    environment_name TEXT NOT NULL,
+    workload_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, name),
+    FOREIGN KEY (organization_id, environment_id) REFERENCES environments(organization_id, id)
+);
+
+CREATE INDEX idx_sandboxes_organization ON sandboxes (organization_id);
+CREATE INDEX idx_sandboxes_owner ON sandboxes (owner_id);
+CREATE INDEX idx_sandboxes_environment ON sandboxes (environment_id);


### PR DESCRIPTION
## Summary
- Adds Agents Service storage, models, converters, and gRPC handlers for sandbox CRUD/management foundation.
- Adds minimal environment storage/handlers needed by sandbox references and the environment deletion guard.
- Wires sandbox authorization tuples/checks to the merged OpenFGA sandbox relations and emits `sandbox.updated` notifications to owner/org rooms.
- Implements sandbox name validation/generation, per-org uniqueness, authenticated owner derivation, status/idle_timeout/ttl/last_session_at/workload_id fields, and environment-name snapshotting.

References agynio/architecture#162.

## Deferrals
- Organization-configurable sandbox TTL/idle-timeout defaults are deferred until an Organizations service client/config is available in Agents Service; this PR snapshots platform defaults (`30m`, `72h`).
- Runtime/orchestrator start/stop/volume lifecycle is deferred to downstream runtime slices. `EnsureSandboxRunning` authorizes and returns already-starting/running sandboxes, rejects terminated sandboxes, and returns `UNIMPLEMENTED` when a stopped/failed sandbox would require runtime orchestration.
- Internal-only enforcement for `UpdateSandboxLastSession` is deferred until the service mesh/internal caller identity path is wired; this handler updates the foundation field for terminal/runtime integrations.

## Validation
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1`
- `git diff --exit-code -- .gen/go/agynio/api/agents/v1 .gen/go/agynio/api/authorization/v1 .gen/go/agynio/api/notifications/v1`
- `gofmt -w internal/server/authorization.go internal/server/authorization_test.go internal/server/converter.go internal/server/converter_test.go internal/server/notifications.go internal/server/sandbox.go internal/store/store.go internal/store/types.go internal/store/sandbox.go`
- `git diff --check`
- `go test -v ./internal/server` — 11 passed / 0 failed / 0 skipped
- `go test ./...` — 1 test package passed / 0 failed / 0 skipped; 5 packages without tests
- `go vet ./...` — passed with no errors
- `go build ./...` — passed