### PR TITLE
feat(agents): add sandbox runtime state updates

### DIFF
--- a/charts/agents/templates/authorization-policy.yaml
+++ b/charts/agents/templates/authorization-policy.yaml
@@ -23,3 +23,28 @@ spec:
               - POST
             paths:
               - /agynio.api.agents.v1.AgentsService/FanoutInboxItem
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Release.Name }}-update-sandbox-runtime-state
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  action: DENY
+  rules:
+    - from:
+        - source:
+            notPrincipals:
+              - "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator"
+      to:
+        - operation:
+            methods:
+              - POST
+            paths:
+              - /agynio.api.agents.v1.AgentsService/UpdateSandboxRuntimeState

--- a/internal/server/authorization_policy_test.go
+++ b/internal/server/authorization_policy_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAuthorizationPolicyRestrictsSandboxRuntimeStateUpdate(t *testing.T) {
+	policy, err := os.ReadFile("../../charts/agents/templates/authorization-policy.yaml")
+	if err != nil {
+		t.Fatalf("read authorization policy: %v", err)
+	}
+	content := string(policy)
+
+	assertContains(t, content, "{{ .Release.Name }}-update-sandbox-runtime-state")
+	assertContains(t, content, "/agynio.api.agents.v1.AgentsService/UpdateSandboxRuntimeState")
+	assertContains(t, content, "notPrincipals:")
+	assertContains(t, content, "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator")
+
+	if strings.Contains(content, "cluster.local/ns/{{ .Release.Namespace }}/sa/gateway") {
+		t.Fatalf("sandbox runtime state update policy must not allow the gateway user path")
+	}
+}
+
+func assertContains(t *testing.T, content string, expected string) {
+	t.Helper()
+	if !strings.Contains(content, expected) {
+		t.Fatalf("expected authorization policy to contain %q", expected)
+	}
+}

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -141,6 +141,113 @@ func TestCreateSandboxWithGeneratedNamePropagatesNonCollision(t *testing.T) {
 	}
 }
 
+func TestSandboxRuntimeStateUpdateFromProtoSetsStatusAndWorkload(t *testing.T) {
+	workloadID := uuid.New()
+	update, err := sandboxRuntimeStateUpdateFromProto(&agentsv1.UpdateSandboxRuntimeStateRequest{
+		Status: ptr(agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING),
+		WorkloadIdUpdate: &agentsv1.UpdateSandboxRuntimeStateRequest_WorkloadId{
+			WorkloadId: workloadID.String(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("runtime state update: %v", err)
+	}
+	if update.Status == nil || *update.Status != store.SandboxStatusRunning {
+		t.Fatalf("expected running status, got %v", update.Status)
+	}
+	if update.WorkloadID == nil || *update.WorkloadID != workloadID {
+		t.Fatalf("expected workload id %s, got %v", workloadID, update.WorkloadID)
+	}
+	if update.ClearWorkloadID {
+		t.Fatalf("expected workload id to remain set")
+	}
+}
+
+func TestSandboxRuntimeStateUpdateFromProtoClearsWorkload(t *testing.T) {
+	update, err := sandboxRuntimeStateUpdateFromProto(&agentsv1.UpdateSandboxRuntimeStateRequest{
+		WorkloadIdUpdate: &agentsv1.UpdateSandboxRuntimeStateRequest_ClearWorkloadId{ClearWorkloadId: true},
+	})
+	if err != nil {
+		t.Fatalf("runtime state update: %v", err)
+	}
+	if !update.ClearWorkloadID {
+		t.Fatalf("expected workload id clear")
+	}
+	if update.WorkloadID != nil {
+		t.Fatalf("expected no workload id, got %v", update.WorkloadID)
+	}
+}
+
+func TestSandboxRuntimeStateUpdateFromProtoRejectsEmptyUpdate(t *testing.T) {
+	_, err := sandboxRuntimeStateUpdateFromProto(&agentsv1.UpdateSandboxRuntimeStateRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
+func TestSandboxRuntimeStateUpdateFromProtoRejectsUnspecifiedStatus(t *testing.T) {
+	_, err := sandboxRuntimeStateUpdateFromProto(&agentsv1.UpdateSandboxRuntimeStateRequest{
+		Status: ptr(agentsv1.SandboxStatus_SANDBOX_STATUS_UNSPECIFIED),
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
+func TestSandboxRestartOnConnectUpdateStopped(t *testing.T) {
+	update, shouldUpdate, err := sandboxRestartOnConnectUpdate(store.SandboxStatusStopped)
+	if err != nil {
+		t.Fatalf("restart on connect update: %v", err)
+	}
+	if !shouldUpdate {
+		t.Fatalf("expected stopped sandbox to transition")
+	}
+	if update.Status == nil || *update.Status != store.SandboxStatusStarting {
+		t.Fatalf("expected starting status, got %v", update.Status)
+	}
+	if !update.ClearWorkloadID {
+		t.Fatalf("expected stale workload id to be cleared")
+	}
+}
+
+func TestSandboxRestartOnConnectUpdateFailed(t *testing.T) {
+	update, shouldUpdate, err := sandboxRestartOnConnectUpdate(store.SandboxStatusFailed)
+	if err != nil {
+		t.Fatalf("restart on connect update: %v", err)
+	}
+	if !shouldUpdate {
+		t.Fatalf("expected failed sandbox to transition")
+	}
+	if update.Status == nil || *update.Status != store.SandboxStatusStarting {
+		t.Fatalf("expected starting status, got %v", update.Status)
+	}
+	if !update.ClearWorkloadID {
+		t.Fatalf("expected stale workload id to be cleared")
+	}
+}
+
+func TestSandboxRestartOnConnectUpdateTerminated(t *testing.T) {
+	_, shouldUpdate, err := sandboxRestartOnConnectUpdate(store.SandboxStatusTerminated)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected failed precondition, got %v", err)
+	}
+	if shouldUpdate {
+		t.Fatalf("expected terminated sandbox to remain unchanged")
+	}
+}
+
+func TestSandboxRestartOnConnectUpdateRunningAndStarting(t *testing.T) {
+	for _, sandboxStatus := range []store.SandboxStatus{store.SandboxStatusRunning, store.SandboxStatusStarting} {
+		_, shouldUpdate, err := sandboxRestartOnConnectUpdate(sandboxStatus)
+		if err != nil {
+			t.Fatalf("restart on connect update for %s: %v", sandboxStatus, err)
+		}
+		if shouldUpdate {
+			t.Fatalf("expected %s sandbox to remain unchanged", sandboxStatus)
+		}
+	}
+}
+
 func TestToProtoSandboxIncludesFoundationFields(t *testing.T) {
 	lastSessionAt := time.Now().UTC()
 	workloadID := uuid.New()
@@ -228,6 +335,10 @@ func (noopNotificationsClient) Publish(context.Context, *notificationsv1.Publish
 
 func (noopNotificationsClient) Subscribe(context.Context, *notificationsv1.SubscribeRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[notificationsv1.SubscribeResponse], error) {
 	return nil, status.Error(codes.Unimplemented, "subscribe")
+}
+
+func ptr[T any](value T) *T {
+	return &value
 }
 
 func TestToProtoAgentInstanceBuildsHandle(t *testing.T) {

--- a/internal/server/notifications_test.go
+++ b/internal/server/notifications_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
 	notificationsv1 "github.com/agynio/agents/.gen/go/agynio/api/notifications/v1"
 	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
@@ -85,6 +86,32 @@ func TestPublishSandboxUpdatedUsesNullOptionalPayloadFields(t *testing.T) {
 	if fields["last_session_at"].GetNullValue() != 0 {
 		t.Fatalf("expected last_session_at null, got %v", fields["last_session_at"])
 	}
+}
+
+func TestSandboxRuntimeStateUpdatedResponsePublishesNotification(t *testing.T) {
+	notifications := &recordingNotificationsClient{}
+	server := &Server{notifications: notifications}
+	sandbox := store.Sandbox{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Name:           "brave-otter-aabbccdd",
+		EnvironmentID:  uuid.New(),
+		OwnerID:        uuid.New(),
+		Status:         store.SandboxStatusStopped,
+		IdleTimeout:    "30m",
+		TTL:            "72h",
+	}
+
+	response := server.sandboxRuntimeStateUpdatedResponse(context.Background(), sandbox)
+
+	if response.GetSandbox().GetStatus() != agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED {
+		t.Fatalf("expected stopped response, got %v", response.GetSandbox().GetStatus())
+	}
+	if len(notifications.published) != 1 {
+		t.Fatalf("expected 1 publish request, got %d", len(notifications.published))
+	}
+	fields := notifications.published[0].GetPayload().GetFields()
+	assertStringField(t, fields, "status", string(store.SandboxStatusStopped))
 }
 
 type recordingNotificationsClient struct {

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -315,13 +315,53 @@ func (s *Server) EnsureSandboxRunning(ctx context.Context, req *agentsv1.EnsureS
 	if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, "can_connect"); err != nil {
 		return nil, err
 	}
-	if sandbox.Status == store.SandboxStatusTerminated {
-		return nil, status.Error(codes.FailedPrecondition, "terminated sandbox cannot be started")
+	update, shouldUpdate, err := sandboxRestartOnConnectUpdate(sandbox.Status)
+	if err != nil {
+		return nil, err
 	}
-	if sandbox.Status == store.SandboxStatusStopped || sandbox.Status == store.SandboxStatusFailed {
-		return nil, status.Error(codes.Unimplemented, "sandbox runtime orchestration is not yet available")
+	if shouldUpdate {
+		sandbox, err = s.store.UpdateSandbox(ctx, sandbox.Meta.ID, update)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		s.publishSandboxUpdated(ctx, sandbox)
 	}
 	return &agentsv1.EnsureSandboxRunningResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+func (s *Server) UpdateSandboxRuntimeState(ctx context.Context, req *agentsv1.UpdateSandboxRuntimeStateRequest) (*agentsv1.UpdateSandboxRuntimeStateResponse, error) {
+	sandboxID, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	update, err := sandboxRuntimeStateUpdateFromProto(req)
+	if err != nil {
+		return nil, err
+	}
+	sandbox, err := s.store.UpdateSandbox(ctx, sandboxID, update)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return s.sandboxRuntimeStateUpdatedResponse(ctx, sandbox), nil
+}
+
+func (s *Server) sandboxRuntimeStateUpdatedResponse(ctx context.Context, sandbox store.Sandbox) *agentsv1.UpdateSandboxRuntimeStateResponse {
+	s.publishSandboxUpdated(ctx, sandbox)
+	return &agentsv1.UpdateSandboxRuntimeStateResponse{Sandbox: toProtoSandbox(sandbox)}
+}
+
+func sandboxRestartOnConnectUpdate(sandboxStatus store.SandboxStatus) (store.SandboxUpdate, bool, error) {
+	switch sandboxStatus {
+	case store.SandboxStatusRunning, store.SandboxStatusStarting:
+		return store.SandboxUpdate{}, false, nil
+	case store.SandboxStatusStopped, store.SandboxStatusFailed:
+		starting := store.SandboxStatusStarting
+		return store.SandboxUpdate{Status: &starting, ClearWorkloadID: true}, true, nil
+	case store.SandboxStatusTerminated:
+		return store.SandboxUpdate{}, false, status.Error(codes.FailedPrecondition, "terminated sandbox cannot be started")
+	default:
+		panic(fmt.Sprintf("unknown sandbox status %q", sandboxStatus))
+	}
 }
 
 func (s *Server) UpdateSandboxLastSession(ctx context.Context, req *agentsv1.UpdateSandboxLastSessionRequest) (*agentsv1.UpdateSandboxLastSessionResponse, error) {
@@ -508,5 +548,55 @@ func sandboxStatusToProto(sandboxStatus store.SandboxStatus) agentsv1.SandboxSta
 		return agentsv1.SandboxStatus_SANDBOX_STATUS_TERMINATED
 	default:
 		panic(fmt.Sprintf("unknown sandbox status %q", sandboxStatus))
+	}
+}
+
+func sandboxRuntimeStateUpdateFromProto(req *agentsv1.UpdateSandboxRuntimeStateRequest) (store.SandboxUpdate, error) {
+	update := store.SandboxUpdate{}
+	if req.Status != nil {
+		statusValue, err := sandboxStatusFromProto(req.GetStatus())
+		if err != nil {
+			return store.SandboxUpdate{}, status.Errorf(codes.InvalidArgument, "status: %v", err)
+		}
+		update.Status = &statusValue
+	}
+	switch workload := req.GetWorkloadIdUpdate().(type) {
+	case *agentsv1.UpdateSandboxRuntimeStateRequest_WorkloadId:
+		workloadID, err := parseUUID(workload.WorkloadId)
+		if err != nil {
+			return store.SandboxUpdate{}, status.Errorf(codes.InvalidArgument, "workload_id: %v", err)
+		}
+		update.WorkloadID = &workloadID
+	case *agentsv1.UpdateSandboxRuntimeStateRequest_ClearWorkloadId:
+		if !workload.ClearWorkloadId {
+			return store.SandboxUpdate{}, status.Error(codes.InvalidArgument, "clear_workload_id must be true when provided")
+		}
+		update.ClearWorkloadID = true
+	case nil:
+	default:
+		return store.SandboxUpdate{}, status.Error(codes.InvalidArgument, "unknown workload_id update")
+	}
+	if update.Status == nil && update.WorkloadID == nil && !update.ClearWorkloadID {
+		return store.SandboxUpdate{}, status.Error(codes.InvalidArgument, "at least one runtime state field must be provided")
+	}
+	return update, nil
+}
+
+func sandboxStatusFromProto(sandboxStatus agentsv1.SandboxStatus) (store.SandboxStatus, error) {
+	switch sandboxStatus {
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_STARTING:
+		return store.SandboxStatusStarting, nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_RUNNING:
+		return store.SandboxStatusRunning, nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_STOPPED:
+		return store.SandboxStatusStopped, nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_FAILED:
+		return store.SandboxStatusFailed, nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_TERMINATED:
+		return store.SandboxStatusTerminated, nil
+	case agentsv1.SandboxStatus_SANDBOX_STATUS_UNSPECIFIED:
+		return "", fmt.Errorf("must be starting, running, stopped, failed, or terminated")
+	default:
+		return "", fmt.Errorf("unknown value %d", sandboxStatus)
 	}
 }

--- a/internal/store/pagination_test.go
+++ b/internal/store/pagination_test.go
@@ -29,3 +29,14 @@ func TestDecodeInboxPageTokenRejectsIDOnlyToken(t *testing.T) {
 		t.Fatalf("expected id-only token to be rejected")
 	}
 }
+
+func TestSandboxUpdateRejectsSetAndClearWorkloadID(t *testing.T) {
+	workloadID := uuid.New()
+	_, err := New(nil).UpdateSandbox(t.Context(), uuid.New(), SandboxUpdate{
+		WorkloadID:      &workloadID,
+		ClearWorkloadID: true,
+	})
+	if err == nil {
+		t.Fatalf("expected set and clear workload_id to be rejected")
+	}
+}

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -169,6 +169,9 @@ func (s *Store) GetSandboxByName(ctx context.Context, organizationID uuid.UUID, 
 }
 
 func (s *Store) UpdateSandbox(ctx context.Context, id uuid.UUID, update SandboxUpdate) (Sandbox, error) {
+	if update.WorkloadID != nil && update.ClearWorkloadID {
+		return Sandbox{}, fmt.Errorf("sandbox update cannot set and clear workload_id")
+	}
 	builder := updateBuilder{}
 	if update.Status != nil {
 		builder.add("status", *update.Status)
@@ -178,6 +181,9 @@ func (s *Store) UpdateSandbox(ctx context.Context, id uuid.UUID, update SandboxU
 	}
 	if update.WorkloadID != nil {
 		builder.add("workload_id", *update.WorkloadID)
+	}
+	if update.ClearWorkloadID {
+		builder.addNull("workload_id")
 	}
 	if builder.empty() {
 		return Sandbox{}, fmt.Errorf("sandbox update requires at least one field")

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -397,9 +397,10 @@ type SandboxInput struct {
 }
 
 type SandboxUpdate struct {
-	Status        *SandboxStatus
-	LastSessionAt *time.Time
-	WorkloadID    *uuid.UUID
+	Status          *SandboxStatus
+	LastSessionAt   *time.Time
+	WorkloadID      *uuid.UUID
+	ClearWorkloadID bool
 }
 
 type AgentFilter struct{}


### PR DESCRIPTION
## Summary

- Implements internal `UpdateSandboxRuntimeState` using the published Agents API contract from agynio/api#162.
- Allows runtime callers to update sandbox status, set workload id, or explicitly clear stale workload id.
- Updates `EnsureSandboxRunning` restart-on-connect behavior:
  - `running` and `starting` return current sandbox
  - `stopped` and `failed` transition to `starting`, clear stale workload id, publish `sandbox.updated`, and return the sandbox
  - `terminated` remains non-connectable with failed precondition
- Keeps runtime-only fields out of user-facing mutations; public CRUD still only updates status through the existing authorized stop/delete paths.
- Adds focused tests for runtime update parsing, restart-on-connect transitions, workload-id clear semantics, and notification publishing.

Closes #63
Refs agynio/architecture#162
Refs agynio/api#162

## Validation

- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/notifications/v1` — passed
- `go test ./...` — passed
- `go build ./...` — passed
- `git diff --check` — passed