### PR TITLE
fix: let a cluster admin list its own sandboxes

### DIFF
--- a/.gen/go/agynio/api/identity/v1/identity.pb.go
+++ b/.gen/go/agynio/api/identity/v1/identity.pb.go
@@ -30,6 +30,7 @@ const (
 	IdentityType_IDENTITY_TYPE_USER           IdentityType = 4
 	IdentityType_IDENTITY_TYPE_APP            IdentityType = 5
 	IdentityType_IDENTITY_TYPE_AGENT_INSTANCE IdentityType = 6
+	IdentityType_IDENTITY_TYPE_SANDBOX        IdentityType = 7
 )
 
 // Enum value maps for IdentityType.
@@ -41,6 +42,7 @@ var (
 		4: "IDENTITY_TYPE_USER",
 		5: "IDENTITY_TYPE_APP",
 		6: "IDENTITY_TYPE_AGENT_INSTANCE",
+		7: "IDENTITY_TYPE_SANDBOX",
 	}
 	IdentityType_value = map[string]int32{
 		"IDENTITY_TYPE_UNSPECIFIED":    0,
@@ -49,6 +51,7 @@ var (
 		"IDENTITY_TYPE_USER":           4,
 		"IDENTITY_TYPE_APP":            5,
 		"IDENTITY_TYPE_AGENT_INSTANCE": 6,
+		"IDENTITY_TYPE_SANDBOX":        7,
 	}
 )
 
@@ -960,14 +963,15 @@ const file_agynio_api_identity_v1_identity_proto_rawDesc = "" +
 	"\x0finstance_suffix\x18\x03 \x01(\tH\x00R\x0einstanceSuffix\x88\x01\x01B\x12\n" +
 	"\x10_instance_suffix\"\\\n" +
 	"\x19BatchGetNicknamesResponse\x12?\n" +
-	"\aentries\x18\x01 \x03(\v2%.agynio.api.identity.v1.NicknameEntryR\aentries*\xce\x01\n" +
+	"\aentries\x18\x01 \x03(\v2%.agynio.api.identity.v1.NicknameEntryR\aentries*\xe9\x01\n" +
 	"\fIdentityType\x12\x1d\n" +
 	"\x19IDENTITY_TYPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13IDENTITY_TYPE_AGENT\x10\x01\x12\x18\n" +
 	"\x14IDENTITY_TYPE_RUNNER\x10\x02\x12\x16\n" +
 	"\x12IDENTITY_TYPE_USER\x10\x04\x12\x15\n" +
 	"\x11IDENTITY_TYPE_APP\x10\x05\x12 \n" +
-	"\x1cIDENTITY_TYPE_AGENT_INSTANCE\x10\x06\"\x04\b\x03\x10\x03*\x15IDENTITY_TYPE_CHANNEL2\xca\x06\n" +
+	"\x1cIDENTITY_TYPE_AGENT_INSTANCE\x10\x06\x12\x19\n" +
+	"\x15IDENTITY_TYPE_SANDBOX\x10\a\"\x04\b\x03\x10\x03*\x15IDENTITY_TYPE_CHANNEL2\xca\x06\n" +
 	"\x0fIdentityService\x12u\n" +
 	"\x10RegisterIdentity\x12/.agynio.api.identity.v1.RegisterIdentityRequest\x1a0.agynio.api.identity.v1.RegisterIdentityResponse\x12r\n" +
 	"\x0fGetIdentityType\x12..agynio.api.identity.v1.GetIdentityTypeRequest\x1a/.agynio.api.identity.v1.GetIdentityTypeResponse\x12\x84\x01\n" +

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -93,6 +93,27 @@ func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uui
 	return s.requireAllowed(ctx, identityID, relation, organizationPrefix+organizationID.String(), status.Errorf(codes.PermissionDenied, "identity lacks %s on organization", relation))
 }
 
+// requireOwnSandboxListing authorizes listing the caller's own sandboxes.
+//
+// Membership is the ordinary route. A cluster admin is not a member of every
+// organization it administers, though, and refusing it here while it may list
+// every sandbox in the same organization is incoherent — the narrower request
+// would be denied and the broader one allowed. So holding can_list_sandboxes
+// also satisfies this.
+func (s *Server) requireOwnSandboxListing(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
+	err := s.requireOrganizationMember(ctx, identityID, organizationID)
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		return err
+	}
+	if listErr := s.requireOrganizationRelation(ctx, identityID, organizationID, "can_list_sandboxes"); listErr != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *Server) requireSandboxRelation(ctx context.Context, identityID uuid.UUID, sandboxID uuid.UUID, relation string) error {
 	return s.requireAllowed(ctx, identityID, relation, sandboxPrefix+sandboxID.String(), status.Errorf(codes.PermissionDenied, "identity lacks %s on sandbox", relation))
 }

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func TestAddAgentAuthorizationWritesAgentOrganizationMembership(t *testing.T) {
@@ -164,6 +166,40 @@ func TestSandboxListFilterDefaultsToCallerOwner(t *testing.T) {
 	})
 }
 
+// A cluster admin is not a member of every organization it administers.
+// Refusing it its own sandboxes while it may list every sandbox in the same
+// organization would deny the narrower request and allow the broader one.
+func TestSandboxListFilterAllowsOwnListingForClusterAdmin(t *testing.T) {
+	authz := &recordingAuthorizationWriter{deniedRelations: map[string]bool{"member": true}}
+	server := &Server{authz: authz}
+	organizationID := uuid.New()
+	identityID := uuid.New()
+
+	filter, err := server.sandboxListFilter(context.Background(), &agentsv1.ListSandboxesRequest{}, organizationID, identityID)
+	if err != nil {
+		t.Fatalf("sandbox list filter: %v", err)
+	}
+	if filter.OwnerID == nil || *filter.OwnerID != identityID {
+		t.Fatalf("expected the caller's own sandboxes, got %v", filter.OwnerID)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "member"),
+		organizationRelationTuple(identityID, organizationID, "can_list_sandboxes"),
+	})
+}
+
+// Holding neither is still a refusal, reported as the membership failure the
+// caller actually hit rather than the fallback's.
+func TestSandboxListFilterRefusesNonMemberWithoutListPermission(t *testing.T) {
+	authz := &recordingAuthorizationWriter{deniedRelations: map[string]bool{"member": true, "can_list_sandboxes": true}}
+	server := &Server{authz: authz}
+
+	_, err := server.sandboxListFilter(context.Background(), &agentsv1.ListSandboxesRequest{}, uuid.New(), uuid.New())
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected the membership refusal, got %v", err)
+	}
+}
+
 func TestSandboxListFilterAllowsOrgWideListAll(t *testing.T) {
 	authz := &recordingAuthorizationWriter{}
 	server := &Server{authz: authz}
@@ -209,10 +245,17 @@ type recordingAuthorizationWriter struct {
 	// which is how a caller holding tuples somewhere else is expressed. A nil map
 	// allows every check.
 	allowedObjects map[string]bool
+	// deniedRelations refuses specific relations regardless of object, which is
+	// how an identity that holds some permissions on an organization but not
+	// others — a cluster admin, which is not a member — is expressed.
+	deniedRelations map[string]bool
 }
 
 func (w *recordingAuthorizationWriter) Check(_ context.Context, req *authorizationv1.CheckRequest, _ ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
 	w.checks = append(w.checks, req)
+	if w.deniedRelations[req.GetTupleKey().GetRelation()] {
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}
 	allowed := w.allowedObjects == nil || w.allowedObjects[req.GetTupleKey().GetObject()]
 	return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 }

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -282,7 +282,7 @@ func (s *Server) sandboxListFilter(ctx context.Context, req *agentsv1.ListSandbo
 	filter := store.SandboxFilter{IncludeTerminated: req.GetIncludeTerminated()}
 	if req.OwnerId == nil {
 		filter.OwnerID = &identityID
-		if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
+		if err := s.requireOwnSandboxListing(ctx, identityID, organizationID); err != nil {
 			return store.SandboxFilter{}, err
 		}
 		return filter, nil
@@ -301,7 +301,7 @@ func (s *Server) sandboxListFilter(ctx context.Context, req *agentsv1.ListSandbo
 	}
 	filter.OwnerID = &ownerID
 	if ownerID == identityID {
-		if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
+		if err := s.requireOwnSandboxListing(ctx, identityID, organizationID); err != nil {
 			return store.SandboxFilter{}, err
 		}
 		return filter, nil


### PR DESCRIPTION
`agyn sandbox list` failed with `identity is not a member of the agent organization`. The CLI authenticates with the cluster-admin bootstrap token, and a cluster admin is not a member of every organization it administers.

Refusing that while the same identity may list **every** sandbox in the organization denies the narrower request and allows the broader one. The own-listing path now accepts `can_list_sandboxes` as well as membership, on both routes that reach it (no `owner_id`, and an `owner_id` naming the caller).

A caller holding neither is still refused, and still reports the membership failure it actually hit rather than the fallback's.

Pairs with agynio/authorization#31, which restores the `or admin from cluster` half of `can_list_sandboxes` that the model had dropped — this change is inert without it.

Two tests added: a cluster admin (member denied, can_list_sandboxes allowed) gets its own sandboxes and both checks are made in order; an identity holding neither is refused. Full suite and vet pass.