### PR TITLE
feat: sandboxes, environments by runner and flavor, org-scoped listing

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -128,7 +128,6 @@ dev:
     namespace: ${AGENTS_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: agents
-      app.kubernetes.io/instance: agents
     containers:
       agents:
         container: agents

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -65,9 +65,13 @@ functions:
                 - name: data
                   mountPath: /opt/app/data
               resources:
+                # Requests are reservations held for the pod's whole life, but a
+                # dev container only needs its build peak briefly and then idles
+                # near 100Mi. Keeping them low lets several services run from
+                # source on one node; the limits still allow a full build.
                 requests:
-                  cpu: 500m
-                  memory: 1Gi
+                  cpu: 100m
+                  memory: 256Mi
                 limits:
                   cpu: "2"
                   memory: 4Gi

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -157,5 +157,3 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -1,0 +1,167 @@
+package db
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/agynio/agents/migrations"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// envOrganizationScopeMigration is the migration under test. It derives an
+// organization for every env already in the table from the target the env
+// carries, so reads can be scoped by it.
+const envOrganizationScopeMigration = "0016_env_organization_scope.sql"
+
+const (
+	organizationOne = "11111111-1111-1111-1111-111111111111"
+	organizationTwo = "22222222-2222-2222-2222-222222222222"
+)
+
+// migrationTestPool connects to the database named by
+// AGENTS_MIGRATION_TEST_DATABASE_URL and empties it first. The variable must
+// name a scratch database, never one holding anything worth keeping. It is
+// unset in ordinary runs and these tests are then skipped, so the package needs
+// no database to be tested.
+func migrationTestPool(ctx context.Context, t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("AGENTS_MIGRATION_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("AGENTS_MIGRATION_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	return pool
+}
+
+func migrationNames(t *testing.T) []string {
+	t.Helper()
+	entries, err := fs.ReadDir(migrations.Files, ".")
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// applyMigrationsBefore brings the database to the state the migration under
+// test will find, recording what it applied the way ApplyMigrations does so the
+// real entry point picks up from there.
+func applyMigrationsBefore(ctx context.Context, t *testing.T, pool *pgxpool.Pool, version string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`); err != nil {
+		t.Fatalf("ensure schema_migrations: %v", err)
+	}
+	for _, name := range migrationNames(t) {
+		if name >= version {
+			return
+		}
+		content, err := migrations.Files.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx, string(content)); err != nil {
+			t.Fatalf("apply migration %s: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx, `INSERT INTO schema_migrations (version) VALUES ($1)`, name); err != nil {
+			t.Fatalf("record migration %s: %v", name, err)
+		}
+	}
+}
+
+// seedEnvsAcrossOrganizations writes one env per target kind, deliberately
+// putting the mcp in a different organization from the agent and the hook so a
+// backfill that guessed a single organization would be caught.
+func seedEnvsAcrossOrganizations(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	statements := []string{
+		`INSERT INTO agents (id, organization_id, name, model, init_image) VALUES
+			('aaaaaaaa-0000-0000-0000-000000000001', '` + organizationOne + `', 'one', uuid_generate_v4(), 'init:1'),
+			('aaaaaaaa-0000-0000-0000-000000000002', '` + organizationTwo + `', 'two', uuid_generate_v4(), 'init:1')`,
+		`INSERT INTO mcps (id, agent_id, name, image) VALUES
+			('bbbbbbbb-0000-0000-0000-000000000001', 'aaaaaaaa-0000-0000-0000-000000000002', 'mcp_one', 'mcp:1')`,
+		`INSERT INTO hooks (id, agent_id, event, image) VALUES
+			('cccccccc-0000-0000-0000-000000000001', 'aaaaaaaa-0000-0000-0000-000000000001', 'pre', 'hook:1')`,
+		`INSERT INTO envs (name, agent_id, value) VALUES ('BY_AGENT', 'aaaaaaaa-0000-0000-0000-000000000001', 'v')`,
+		`INSERT INTO envs (name, mcp_id, value) VALUES ('BY_MCP', 'bbbbbbbb-0000-0000-0000-000000000001', 'v')`,
+		`INSERT INTO envs (name, hook_id, secret_id) VALUES ('BY_HOOK', 'cccccccc-0000-0000-0000-000000000001', uuid_generate_v4())`,
+	}
+	for _, statement := range statements {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+}
+
+func TestEnvOrganizationBackfillFollowsTheTargetsParentChain(t *testing.T) {
+	ctx := context.Background()
+	pool := migrationTestPool(ctx, t)
+	applyMigrationsBefore(ctx, t, pool, envOrganizationScopeMigration)
+	seedEnvsAcrossOrganizations(ctx, t, pool)
+
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	expected := map[string]string{
+		"BY_AGENT": organizationOne,
+		// An mcp and a hook carry an agent rather than an organization, so the
+		// backfill has to go through it to reach one.
+		"BY_MCP":  organizationTwo,
+		"BY_HOOK": organizationOne,
+	}
+	for name, organizationID := range expected {
+		var actual string
+		if err := pool.QueryRow(ctx, `SELECT organization_id::text FROM envs WHERE name = $1`, name).Scan(&actual); err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if actual != organizationID {
+			t.Fatalf("expected %s in organization %s, got %s", name, organizationID, actual)
+		}
+	}
+}
+
+// An env that reaches no organization is corruption, and the migration stops
+// rather than deleting the row or inventing an organization for it. Migrations
+// apply in one transaction, so stopping leaves the database as it was.
+func TestEnvOrganizationBackfillStopsOnAnEnvWithNoOrganization(t *testing.T) {
+	ctx := context.Background()
+	pool := migrationTestPool(ctx, t)
+	applyMigrationsBefore(ctx, t, pool, envOrganizationScopeMigration)
+	seedEnvsAcrossOrganizations(ctx, t, pool)
+	if _, err := pool.Exec(ctx, `ALTER TABLE envs DROP CONSTRAINT envs_check`); err != nil {
+		t.Fatalf("drop target check: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO envs (name, value) VALUES ('ORPHAN', 'v')`); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
+	if err := ApplyMigrations(ctx, pool); err == nil {
+		t.Fatal("expected the migration to stop on an env with no organization")
+	}
+
+	var columns int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM information_schema.columns WHERE table_name = 'envs' AND column_name = 'organization_id'`,
+	).Scan(&columns); err != nil {
+		t.Fatalf("inspect envs: %v", err)
+	}
+	if columns != 0 {
+		t.Fatal("expected the migration to roll back and leave envs untouched")
+	}
+}

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// envOrganizationScopeMigration is the migration under test. It derives an
-// organization for every env already in the table from the target the env
-// carries, so reads can be scoped by it.
-const envOrganizationScopeMigration = "0016_env_organization_scope.sql"
+// The migrations under test. Each derives an organization for every row already
+// in its table from the target that row carries, so reads can be scoped by it.
+const (
+	envOrganizationScopeMigration                       = "0016_env_organization_scope.sql"
+	imagePullSecretAttachmentOrganizationScopeMigration = "0017_image_pull_secret_attachment_organization_scope.sql"
+)
 
 const (
 	organizationOne = "11111111-1111-1111-1111-111111111111"
@@ -84,12 +86,22 @@ func applyMigrationsBefore(ctx context.Context, t *testing.T, pool *pgxpool.Pool
 	}
 }
 
-// seedEnvsAcrossOrganizations writes one env per target kind, deliberately
-// putting the mcp in a different organization from the agent and the hook so a
-// backfill that guessed a single organization would be caught.
-func seedEnvsAcrossOrganizations(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+func execAll(ctx context.Context, t *testing.T, pool *pgxpool.Pool, statements []string) {
 	t.Helper()
-	statements := []string{
+	for _, statement := range statements {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+}
+
+// seedTargetsAcrossOrganizations writes the agents, mcps and hooks a scoped row
+// can point at, deliberately putting the mcp in a different organization from
+// the agent and the hook so a backfill that guessed a single organization would
+// be caught.
+func seedTargetsAcrossOrganizations(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	execAll(ctx, t, pool, []string{
 		`INSERT INTO agents (id, organization_id, name, model, init_image) VALUES
 			('aaaaaaaa-0000-0000-0000-000000000001', '` + organizationOne + `', 'one', uuid_generate_v4(), 'init:1'),
 			('aaaaaaaa-0000-0000-0000-000000000002', '` + organizationTwo + `', 'two', uuid_generate_v4(), 'init:1')`,
@@ -97,15 +109,33 @@ func seedEnvsAcrossOrganizations(ctx context.Context, t *testing.T, pool *pgxpoo
 			('bbbbbbbb-0000-0000-0000-000000000001', 'aaaaaaaa-0000-0000-0000-000000000002', 'mcp_one', 'mcp:1')`,
 		`INSERT INTO hooks (id, agent_id, event, image) VALUES
 			('cccccccc-0000-0000-0000-000000000001', 'aaaaaaaa-0000-0000-0000-000000000001', 'pre', 'hook:1')`,
+	})
+}
+
+// seedEnvsAcrossOrganizations writes one env per target kind.
+func seedEnvsAcrossOrganizations(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	seedTargetsAcrossOrganizations(ctx, t, pool)
+	execAll(ctx, t, pool, []string{
 		`INSERT INTO envs (name, agent_id, value) VALUES ('BY_AGENT', 'aaaaaaaa-0000-0000-0000-000000000001', 'v')`,
 		`INSERT INTO envs (name, mcp_id, value) VALUES ('BY_MCP', 'bbbbbbbb-0000-0000-0000-000000000001', 'v')`,
 		`INSERT INTO envs (name, hook_id, secret_id) VALUES ('BY_HOOK', 'cccccccc-0000-0000-0000-000000000001', uuid_generate_v4())`,
-	}
-	for _, statement := range statements {
-		if _, err := pool.Exec(ctx, statement); err != nil {
-			t.Fatalf("seed: %v", err)
-		}
-	}
+	})
+}
+
+// seedImagePullSecretAttachmentsAcrossOrganizations writes one attachment per
+// target kind. The rows carry no name, so each is identified by a fixed id.
+func seedImagePullSecretAttachmentsAcrossOrganizations(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	seedTargetsAcrossOrganizations(ctx, t, pool)
+	execAll(ctx, t, pool, []string{
+		`INSERT INTO image_pull_secret_attachments (id, image_pull_secret_id, agent_id) VALUES
+			('dddddddd-0000-0000-0000-000000000001', uuid_generate_v4(), 'aaaaaaaa-0000-0000-0000-000000000001')`,
+		`INSERT INTO image_pull_secret_attachments (id, image_pull_secret_id, mcp_id) VALUES
+			('dddddddd-0000-0000-0000-000000000002', uuid_generate_v4(), 'bbbbbbbb-0000-0000-0000-000000000001')`,
+		`INSERT INTO image_pull_secret_attachments (id, image_pull_secret_id, hook_id) VALUES
+			('dddddddd-0000-0000-0000-000000000003', uuid_generate_v4(), 'cccccccc-0000-0000-0000-000000000001')`,
+	})
 }
 
 func TestEnvOrganizationBackfillFollowsTheTargetsParentChain(t *testing.T) {
@@ -163,5 +193,64 @@ func TestEnvOrganizationBackfillStopsOnAnEnvWithNoOrganization(t *testing.T) {
 	}
 	if columns != 0 {
 		t.Fatal("expected the migration to roll back and leave envs untouched")
+	}
+}
+
+func TestImagePullSecretAttachmentOrganizationBackfillFollowsTheTargetsParentChain(t *testing.T) {
+	ctx := context.Background()
+	pool := migrationTestPool(ctx, t)
+	applyMigrationsBefore(ctx, t, pool, imagePullSecretAttachmentOrganizationScopeMigration)
+	seedImagePullSecretAttachmentsAcrossOrganizations(ctx, t, pool)
+
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	expected := map[string]string{
+		"dddddddd-0000-0000-0000-000000000001": organizationOne,
+		// An mcp and a hook carry an agent rather than an organization, so the
+		// backfill has to go through it to reach one.
+		"dddddddd-0000-0000-0000-000000000002": organizationTwo,
+		"dddddddd-0000-0000-0000-000000000003": organizationOne,
+	}
+	for id, organizationID := range expected {
+		var actual string
+		if err := pool.QueryRow(ctx, `SELECT organization_id::text FROM image_pull_secret_attachments WHERE id = $1`, id).Scan(&actual); err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		if actual != organizationID {
+			t.Fatalf("expected %s in organization %s, got %s", id, organizationID, actual)
+		}
+	}
+}
+
+// An attachment that reaches no organization is corruption, and the migration
+// stops rather than deleting the row or inventing an organization for it.
+// Migrations apply in one transaction, so stopping leaves the database as it
+// was.
+func TestImagePullSecretAttachmentOrganizationBackfillStopsOnAnAttachmentWithNoOrganization(t *testing.T) {
+	ctx := context.Background()
+	pool := migrationTestPool(ctx, t)
+	applyMigrationsBefore(ctx, t, pool, imagePullSecretAttachmentOrganizationScopeMigration)
+	seedImagePullSecretAttachmentsAcrossOrganizations(ctx, t, pool)
+	if _, err := pool.Exec(ctx, `ALTER TABLE image_pull_secret_attachments DROP CONSTRAINT image_pull_secret_attachments_check`); err != nil {
+		t.Fatalf("drop target check: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO image_pull_secret_attachments (image_pull_secret_id) VALUES (uuid_generate_v4())`); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
+	if err := ApplyMigrations(ctx, pool); err == nil {
+		t.Fatal("expected the migration to stop on an attachment with no organization")
+	}
+
+	var columns int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM information_schema.columns WHERE table_name = 'image_pull_secret_attachments' AND column_name = 'organization_id'`,
+	).Scan(&columns); err != nil {
+		t.Fatalf("inspect image_pull_secret_attachments: %v", err)
+	}
+	if columns != 0 {
+		t.Fatal("expected the migration to roll back and leave image_pull_secret_attachments untouched")
 	}
 }

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -41,6 +41,54 @@ func (s *Server) requireOrganizationMember(ctx context.Context, identityID uuid.
 	return nil
 }
 
+// organizationListScope settles which organization a list RPC reads, and
+// authorizes it.
+//
+// An internal caller reaches these RPCs over the mesh rather than the Gateway
+// and carries no identity by design — the Agents Orchestrator holds no OpenFGA
+// tuples, so a check could only ever refuse it — and reads whatever scope it
+// asked for, including none at all. A caller that does present an identity is a
+// user request: it names the organization it is reading and must be a member of
+// it, so it cannot reach the unscoped internal path by leaving the organization
+// out. A malformed identity is still rejected.
+//
+// The returned scope is nil only for an internal caller that named no
+// organization.
+func (s *Server) organizationListScope(ctx context.Context, organizationID string) (*uuid.UUID, error) {
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !hasIdentity && organizationID == "" {
+		return nil, nil
+	}
+	parsed, err := parseUUID(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	if hasIdentity {
+		if err := s.requireOrganizationMember(ctx, identityID, parsed); err != nil {
+			return nil, err
+		}
+	}
+	return &parsed, nil
+}
+
+// requireOrganizationListAccess authorizes a list RPC that always names the
+// organization it reads, on the same terms as organizationListScope: an
+// identified caller must be a member of that organization, an internal caller
+// holds no tuples and is served.
+func (s *Server) requireOrganizationListAccess(ctx context.Context, organizationID uuid.UUID) error {
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasIdentity {
+		return nil
+	}
+	return s.requireOrganizationMember(ctx, identityID, organizationID)
+}
+
 func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) error {
 	return s.requireAllowed(ctx, identityID, relation, organizationPrefix+organizationID.String(), status.Errorf(codes.PermissionDenied, "identity lacks %s on organization", relation))
 }

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -128,6 +128,24 @@ func TestRemoveSandboxAuthorizationDeletesOrgAndOwner(t *testing.T) {
 	})
 }
 
+func TestSandboxReadableWithoutCheck(t *testing.T) {
+	sandboxID := uuid.New()
+	ownerID := uuid.New()
+	sandbox := store.Sandbox{Meta: store.EntityMeta{ID: sandboxID}, OwnerID: ownerID}
+
+	if !sandboxReadableWithoutCheck(sandbox, ownerID) {
+		t.Fatalf("expected the owner to read the sandbox without a check")
+	}
+	// The sandbox workload authenticates as its sandbox and holds no tuple; the
+	// platform services it dials resolve it through this record.
+	if !sandboxReadableWithoutCheck(sandbox, sandboxID) {
+		t.Fatalf("expected the sandbox workload to read its own record")
+	}
+	if sandboxReadableWithoutCheck(sandbox, uuid.New()) {
+		t.Fatalf("expected any other identity to need a check")
+	}
+}
+
 func TestSandboxListFilterDefaultsToCallerOwner(t *testing.T) {
 	authz := &recordingAuthorizationWriter{}
 	server := &Server{authz: authz}

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestAddAgentAuthorizationWritesAgentOrganizationMembership(t *testing.T) {
@@ -297,4 +298,38 @@ func TestRemoveAgentInstanceAuthorizationDeletesClassOrgMembership(t *testing.T)
 		agentInstanceOrganizationTuple(instance.Meta.ID, instance.OrganizationID),
 		agentInstanceIdentityOrganizationMembershipTuple(instance.Meta.ID, instance.OrganizationID),
 	})
+}
+
+func TestOptionalIdentityAbsentForInternalCaller(t *testing.T) {
+	// The orchestrator reaches ListSandboxes over the mesh without an identity;
+	// absence must be reported rather than rejected, so the RPC can serve both
+	// the internal reconcile path and Gateway-fronted user requests.
+	id, ok, err := optionalIdentityUUIDFromContext(context.Background())
+	if err != nil {
+		t.Fatalf("optional identity: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected no identity, got %s", id)
+	}
+}
+
+func TestOptionalIdentityRejectsMalformedValue(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", "not-a-uuid"))
+
+	if _, _, err := optionalIdentityUUIDFromContext(ctx); err == nil {
+		t.Fatal("expected malformed identity to be rejected")
+	}
+}
+
+func TestOptionalIdentityReturnsCallerIdentity(t *testing.T) {
+	identityID := uuid.New()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+
+	got, ok, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		t.Fatalf("optional identity: %v", err)
+	}
+	if !ok || got != identityID {
+		t.Fatalf("expected identity %s, got %s (ok=%v)", identityID, got, ok)
+	}
 }

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -356,3 +356,16 @@ func TestOptionalIdentityReturnsCallerIdentity(t *testing.T) {
 		t.Fatalf("expected identity %s, got %s (ok=%v)", identityID, got, ok)
 	}
 }
+
+func TestGetSandboxServesTheInternalCallerWithoutAnIdentity(t *testing.T) {
+	// The Runners service resolves a sandbox-owned workload's owner through
+	// GetSandbox, and the Orchestrator reads it while reconciling. Neither
+	// carries an identity, and demanding one stalled every sandbox at starting.
+	_, hasIdentity, err := optionalIdentityUUIDFromContext(context.Background())
+	if err != nil {
+		t.Fatalf("optional identity: %v", err)
+	}
+	if hasIdentity {
+		t.Fatal("expected no identity for an internal caller")
+	}
+}

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -205,11 +205,16 @@ func TestSandboxListFilterRequiresListPermissionForOtherOwner(t *testing.T) {
 type recordingAuthorizationWriter struct {
 	writes []*authorizationv1.WriteRequest
 	checks []*authorizationv1.CheckRequest
+	// allowedObjects, when set, are the only objects a check is allowed against,
+	// which is how a caller holding tuples somewhere else is expressed. A nil map
+	// allows every check.
+	allowedObjects map[string]bool
 }
 
 func (w *recordingAuthorizationWriter) Check(_ context.Context, req *authorizationv1.CheckRequest, _ ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
 	w.checks = append(w.checks, req)
-	return &authorizationv1.CheckResponse{Allowed: true}, nil
+	allowed := w.allowedObjects == nil || w.allowedObjects[req.GetTupleKey().GetObject()]
+	return &authorizationv1.CheckResponse{Allowed: allowed}, nil
 }
 
 func (w *recordingAuthorizationWriter) Write(_ context.Context, req *authorizationv1.WriteRequest, _ ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -111,14 +111,23 @@ func toProtoImagePullSecretAttachment(attachment store.ImagePullSecretAttachment
 }
 
 func toProtoEnvironment(environment store.Environment) *agentsv1.Environment {
-	return &agentsv1.Environment{
+	proto := &agentsv1.Environment{
 		Meta:           toProtoEntityMeta(environment.Meta),
 		OrganizationId: environment.OrganizationID.String(),
 		Name:           environment.Name,
-		FlavorId:       environment.FlavorID.String(),
 		Image:          environment.Image,
+		Flavor:         environment.Flavor,
 		FlavorName:     environment.FlavorName,
 	}
+	if environment.RunnerID != nil {
+		proto.RunnerId = environment.RunnerID.String()
+	}
+	// Deprecated, and null for environments created since placement moved to
+	// runner plus flavor name.
+	if environment.FlavorID != nil {
+		proto.FlavorId = environment.FlavorID.String()
+	}
+	return proto
 }
 
 func toProtoSandbox(sandbox store.Sandbox) *agentsv1.Sandbox {

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -107,6 +107,10 @@ func toProtoImagePullSecretAttachment(attachment store.ImagePullSecretAttachment
 		protoAttachment.Target = &agentsv1.ImagePullSecretAttachment_HookId{HookId: attachment.HookID.String()}
 		return protoAttachment
 	}
+	if attachment.EnvironmentID != nil {
+		protoAttachment.Target = &agentsv1.ImagePullSecretAttachment_EnvironmentId{EnvironmentId: attachment.EnvironmentID.String()}
+		return protoAttachment
+	}
 	panic("image pull secret attachment missing target")
 }
 

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -198,6 +198,8 @@ func toProtoEnv(env store.Env) *agentsv1.Env {
 		protoEnv.Target = &agentsv1.Env_McpId{McpId: env.McpID.String()}
 	} else if env.HookID != nil {
 		protoEnv.Target = &agentsv1.Env_HookId{HookId: env.HookID.String()}
+	} else if env.EnvironmentID != nil {
+		protoEnv.Target = &agentsv1.Env_EnvironmentId{EnvironmentId: env.EnvironmentID.String()}
 	} else {
 		panic("env missing target")
 	}

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -374,3 +374,21 @@ func TestToProtoAgentInstanceBuildsHandle(t *testing.T) {
 		t.Fatalf("unexpected pause reason %q", protoInstance.GetPauseReason())
 	}
 }
+
+func TestToProtoEnvCarriesTheEnvironmentTarget(t *testing.T) {
+	environmentID := uuid.New()
+	value := "value"
+	env := store.Env{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Name:           "TOKEN",
+		EnvironmentID:  &environmentID,
+		Value:          &value,
+	}
+
+	protoEnv := toProtoEnv(env)
+
+	if protoEnv.GetEnvironmentId() != environmentID.String() {
+		t.Fatalf("expected environment target %s, got %q", environmentID, protoEnv.GetEnvironmentId())
+	}
+}

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -375,6 +375,22 @@ func TestToProtoAgentInstanceBuildsHandle(t *testing.T) {
 	}
 }
 
+func TestToProtoImagePullSecretAttachmentCarriesTheEnvironmentTarget(t *testing.T) {
+	environmentID := uuid.New()
+	attachment := store.ImagePullSecretAttachment{
+		Meta:              store.EntityMeta{ID: uuid.New()},
+		OrganizationID:    uuid.New(),
+		ImagePullSecretID: uuid.New(),
+		EnvironmentID:     &environmentID,
+	}
+
+	protoAttachment := toProtoImagePullSecretAttachment(attachment)
+
+	if protoAttachment.GetEnvironmentId() != environmentID.String() {
+		t.Fatalf("expected environment target %s, got %q", environmentID, protoAttachment.GetEnvironmentId())
+	}
+}
+
 func TestToProtoEnvCarriesTheEnvironmentTarget(t *testing.T) {
 	environmentID := uuid.New()
 	value := "value"

--- a/internal/server/env_test.go
+++ b/internal/server/env_test.go
@@ -14,6 +14,10 @@ func identityContext(identityID uuid.UUID) context.Context {
 	return metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
 }
 
+func malformedIdentityContext() context.Context {
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", "not-a-uuid"))
+}
+
 // An env names a value or a secret belonging to one organization, and ListEnvs
 // used to authorize nothing at all: any caller who could reach the RPC could
 // read any organization's envs by naming an id from it.

--- a/internal/server/env_test.go
+++ b/internal/server/env_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
+)
+
+func identityContext(identityID uuid.UUID) context.Context {
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+}
+
+// An env names a value or a secret belonging to one organization, and ListEnvs
+// used to authorize nothing at all: any caller who could reach the RPC could
+// read any organization's envs by naming an id from it.
+func TestEnvListFilterRefusesAnotherOrganizationsEnvs(t *testing.T) {
+	callerOrganizationID := uuid.New()
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + callerOrganizationID.String(): true,
+	}}
+	server := &Server{authz: authz}
+
+	filter, err := server.envListFilter(identityContext(identityID), &agentsv1.ListEnvsRequest{
+		OrganizationId: organizationID.String(),
+	})
+	if err == nil {
+		t.Fatal("expected a caller from another organization to be refused")
+	}
+	if filter.OrganizationID != nil || filter.AgentID != nil || filter.McpID != nil || filter.HookID != nil || filter.EnvironmentID != nil {
+		t.Fatalf("expected no filter to be returned on refusal, got %#v", filter)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "member"),
+	})
+}
+
+// Naming an id from another organization must not smuggle a read past the
+// check: the organization is what is authorized, and the targets only narrow
+// the result within it.
+func TestEnvListFilterRefusesAnotherOrganizationsEnvsWhenNarrowedByTarget(t *testing.T) {
+	callerOrganizationID := uuid.New()
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + callerOrganizationID.String(): true,
+	}}
+	server := &Server{authz: authz}
+
+	if _, err := server.envListFilter(identityContext(identityID), &agentsv1.ListEnvsRequest{
+		OrganizationId: organizationID.String(),
+		AgentId:        uuid.NewString(),
+	}); err == nil {
+		t.Fatal("expected a caller from another organization to be refused")
+	}
+}
+
+// Listing an organization's envs without narrowing them is a legitimate read
+// once the organization is authorized; it used to be refused outright because
+// the table carried no organization to scope it by.
+func TestEnvListFilterScopesAnUnfilteredListToTheOrganization(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	organizationID := uuid.New()
+	identityID := uuid.New()
+
+	filter, err := server.envListFilter(identityContext(identityID), &agentsv1.ListEnvsRequest{
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("env list filter: %v", err)
+	}
+	if filter.OrganizationID == nil || *filter.OrganizationID != organizationID {
+		t.Fatalf("expected organization filter %s, got %v", organizationID, filter.OrganizationID)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "member"),
+	})
+}
+
+// A caller that presents an identity is a user request and cannot fall through
+// to the unscoped internal path by leaving the organization out.
+func TestEnvListFilterRequiresAnOrganizationFromAnIdentifiedCaller(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if _, err := server.envListFilter(identityContext(uuid.New()), &agentsv1.ListEnvsRequest{}); err == nil {
+		t.Fatal("expected a request without an organization to be rejected")
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+// The Agents Orchestrator lists an environment's envs while assembling a
+// sandbox workload. It reaches the RPC over the mesh and carries no identity by
+// design, holding no tuples any check could pass.
+func TestEnvListFilterServesTheInternalCallerWithoutAnIdentity(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	environmentID := uuid.New()
+
+	filter, err := server.envListFilter(context.Background(), &agentsv1.ListEnvsRequest{
+		EnvironmentId: environmentID.String(),
+	})
+	if err != nil {
+		t.Fatalf("env list filter: %v", err)
+	}
+	if filter.EnvironmentID == nil || *filter.EnvironmentID != environmentID {
+		t.Fatalf("expected environment filter %s, got %v", environmentID, filter.EnvironmentID)
+	}
+	if filter.OrganizationID != nil {
+		t.Fatalf("expected no organization filter, got %s", filter.OrganizationID)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+// An internal caller that does name an organization is still held to it.
+func TestEnvListFilterScopesTheInternalCallerToANamedOrganization(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	organizationID := uuid.New()
+
+	filter, err := server.envListFilter(context.Background(), &agentsv1.ListEnvsRequest{
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("env list filter: %v", err)
+	}
+	if filter.OrganizationID == nil || *filter.OrganizationID != organizationID {
+		t.Fatalf("expected organization filter %s, got %v", organizationID, filter.OrganizationID)
+	}
+}
+
+func TestEnvListFilterNarrowsByEveryTarget(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	mcpID := uuid.New()
+	hookID := uuid.New()
+	environmentID := uuid.New()
+
+	filter, err := server.envListFilter(identityContext(uuid.New()), &agentsv1.ListEnvsRequest{
+		OrganizationId: organizationID.String(),
+		AgentId:        agentID.String(),
+		McpId:          mcpID.String(),
+		HookId:         hookID.String(),
+		EnvironmentId:  environmentID.String(),
+	})
+	if err != nil {
+		t.Fatalf("env list filter: %v", err)
+	}
+	for name, pair := range map[string][2]*uuid.UUID{
+		"organization": {filter.OrganizationID, &organizationID},
+		"agent":        {filter.AgentID, &agentID},
+		"mcp":          {filter.McpID, &mcpID},
+		"hook":         {filter.HookID, &hookID},
+		"environment":  {filter.EnvironmentID, &environmentID},
+	} {
+		if pair[0] == nil || *pair[0] != *pair[1] {
+			t.Fatalf("expected %s filter %s, got %v", name, pair[1], pair[0])
+		}
+	}
+}
+
+func TestEnvListFilterRejectsAMalformedOrganization(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	if _, err := server.envListFilter(identityContext(uuid.New()), &agentsv1.ListEnvsRequest{
+		OrganizationId: "not-a-uuid",
+	}); err == nil {
+		t.Fatal("expected a malformed organization to be rejected")
+	}
+}

--- a/internal/server/image_pull_secret_attachment_test.go
+++ b/internal/server/image_pull_secret_attachment_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/google/uuid"
+)
+
+// An image pull secret attachment names a registry credential belonging to one
+// organization, and ListImagePullSecretAttachments used to authorize nothing at
+// all: any caller who could reach the RPC could read any organization's
+// attachments by naming an id from it.
+func TestImagePullSecretAttachmentListFilterRefusesAnotherOrganizationsAttachments(t *testing.T) {
+	callerOrganizationID := uuid.New()
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + callerOrganizationID.String(): true,
+	}}
+	server := &Server{authz: authz}
+
+	filter, err := server.imagePullSecretAttachmentListFilter(identityContext(identityID), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		OrganizationId: organizationID.String(),
+	})
+	if err == nil {
+		t.Fatal("expected a caller from another organization to be refused")
+	}
+	if filter.OrganizationID != nil || filter.ImagePullSecretID != nil || filter.AgentID != nil || filter.McpID != nil || filter.HookID != nil || filter.EnvironmentID != nil {
+		t.Fatalf("expected no filter to be returned on refusal, got %#v", filter)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "member"),
+	})
+}
+
+// Naming an id from another organization must not smuggle a read past the
+// check: the organization is what is authorized, and the targets only narrow
+// the result within it.
+func TestImagePullSecretAttachmentListFilterRefusesAnotherOrganizationsAttachmentsWhenNarrowedByTarget(t *testing.T) {
+	callerOrganizationID := uuid.New()
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + callerOrganizationID.String(): true,
+	}}
+	server := &Server{authz: authz}
+
+	if _, err := server.imagePullSecretAttachmentListFilter(identityContext(identityID), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		OrganizationId: organizationID.String(),
+		EnvironmentId:  uuid.NewString(),
+	}); err == nil {
+		t.Fatal("expected a caller from another organization to be refused")
+	}
+}
+
+// Listing an organization's attachments without narrowing them is a legitimate
+// read once the organization is authorized; it used to be refused outright
+// because the table carried no organization to scope it by.
+func TestImagePullSecretAttachmentListFilterScopesAnUnfilteredListToTheOrganization(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	organizationID := uuid.New()
+	identityID := uuid.New()
+
+	filter, err := server.imagePullSecretAttachmentListFilter(identityContext(identityID), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("image pull secret attachment list filter: %v", err)
+	}
+	if filter.OrganizationID == nil || *filter.OrganizationID != organizationID {
+		t.Fatalf("expected organization filter %s, got %v", organizationID, filter.OrganizationID)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, organizationID, "member"),
+	})
+}
+
+// A caller that presents an identity is a user request and cannot fall through
+// to the unscoped internal path by leaving the organization out.
+func TestImagePullSecretAttachmentListFilterRequiresAnOrganizationFromAnIdentifiedCaller(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if _, err := server.imagePullSecretAttachmentListFilter(identityContext(uuid.New()), &agentsv1.ListImagePullSecretAttachmentsRequest{}); err == nil {
+		t.Fatal("expected a request without an organization to be rejected")
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+// The Agents Orchestrator lists an environment's image pull secret attachments
+// while assembling a sandbox workload, immediately after listing its envs. It
+// reaches the RPC over the mesh and carries no identity by design, holding no
+// tuples any check could pass.
+func TestImagePullSecretAttachmentListFilterServesTheInternalCallerWithoutAnIdentity(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	environmentID := uuid.New()
+
+	filter, err := server.imagePullSecretAttachmentListFilter(context.Background(), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		EnvironmentId: environmentID.String(),
+	})
+	if err != nil {
+		t.Fatalf("image pull secret attachment list filter: %v", err)
+	}
+	if filter.EnvironmentID == nil || *filter.EnvironmentID != environmentID {
+		t.Fatalf("expected environment filter %s, got %v", environmentID, filter.EnvironmentID)
+	}
+	if filter.OrganizationID != nil {
+		t.Fatalf("expected no organization filter, got %s", filter.OrganizationID)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+// An internal caller that does name an organization is still held to it.
+func TestImagePullSecretAttachmentListFilterScopesTheInternalCallerToANamedOrganization(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	organizationID := uuid.New()
+
+	filter, err := server.imagePullSecretAttachmentListFilter(context.Background(), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("image pull secret attachment list filter: %v", err)
+	}
+	if filter.OrganizationID == nil || *filter.OrganizationID != organizationID {
+		t.Fatalf("expected organization filter %s, got %v", organizationID, filter.OrganizationID)
+	}
+}
+
+func TestImagePullSecretAttachmentListFilterNarrowsByEveryTarget(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	organizationID := uuid.New()
+	imagePullSecretID := uuid.New()
+	agentID := uuid.New()
+	mcpID := uuid.New()
+	hookID := uuid.New()
+	environmentID := uuid.New()
+
+	filter, err := server.imagePullSecretAttachmentListFilter(identityContext(uuid.New()), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		OrganizationId:    organizationID.String(),
+		ImagePullSecretId: imagePullSecretID.String(),
+		AgentId:           agentID.String(),
+		McpId:             mcpID.String(),
+		HookId:            hookID.String(),
+		EnvironmentId:     environmentID.String(),
+	})
+	if err != nil {
+		t.Fatalf("image pull secret attachment list filter: %v", err)
+	}
+	for name, pair := range map[string][2]*uuid.UUID{
+		"organization":      {filter.OrganizationID, &organizationID},
+		"image pull secret": {filter.ImagePullSecretID, &imagePullSecretID},
+		"agent":             {filter.AgentID, &agentID},
+		"mcp":               {filter.McpID, &mcpID},
+		"hook":              {filter.HookID, &hookID},
+		"environment":       {filter.EnvironmentID, &environmentID},
+	} {
+		if pair[0] == nil || *pair[0] != *pair[1] {
+			t.Fatalf("expected %s filter %s, got %v", name, pair[1], pair[0])
+		}
+	}
+}
+
+func TestImagePullSecretAttachmentListFilterRejectsAMalformedOrganization(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	if _, err := server.imagePullSecretAttachmentListFilter(identityContext(uuid.New()), &agentsv1.ListImagePullSecretAttachmentsRequest{
+		OrganizationId: "not-a-uuid",
+	}); err == nil {
+		t.Fatal("expected a malformed organization to be rejected")
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -153,18 +153,15 @@ func (s *Server) GetInstance(ctx context.Context, req *agentsv1.GetInstanceReque
 }
 
 func (s *Server) ListInstances(ctx context.Context, req *agentsv1.ListInstancesRequest) (*agentsv1.ListInstancesResponse, error) {
+	organizationID, err := s.organizationListScope(ctx, req.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
 	cursor, err := decodePageCursor(req.GetPageToken())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
-	filter := store.AgentInstanceFilter{}
-	if req.GetOrganizationId() != "" {
-		organizationID, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		filter.OrganizationID = &organizationID
-	}
+	filter := store.AgentInstanceFilter{OrganizationID: organizationID}
 	if req.AgentId != nil {
 		agentID, err := parseUUID(req.GetAgentId())
 		if err != nil {

--- a/internal/server/list_authorization_test.go
+++ b/internal/server/list_authorization_test.go
@@ -1,0 +1,214 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/google/uuid"
+)
+
+// These RPCs used to authorize nothing at all: each took an organization id (or
+// an id from which one resolves) and returned rows, so knowing an id was the
+// permission. What follows checks the decision each one now makes.
+//
+// The Server's store is a concrete type these tests do not stand up, so every
+// case that is meant to survive authorization carries a page token that cannot
+// be decoded. The request then stops on the token, one step past the check and
+// short of the database, and what is asserted is the authorization outcome: how
+// many checks were made, against which object, and whether the request lived
+// through them. A refusal never gets that far and needs no such device.
+const undecodablePageToken = "not-a-page-token"
+
+// listRPC is one of the list RPCs under test, reduced to what authorization
+// sees: the organization named in the request, and the call itself.
+type listRPC struct {
+	name string
+	call func(server *Server, ctx context.Context, organizationID string) error
+}
+
+func listRPCs() []listRPC {
+	return []listRPC{
+		{
+			name: "ListAgents",
+			call: func(server *Server, ctx context.Context, organizationID string) error {
+				_, err := server.ListAgents(ctx, &agentsv1.ListAgentsRequest{
+					OrganizationId: organizationID,
+					PageToken:      undecodablePageToken,
+				})
+				return err
+			},
+		},
+		{
+			name: "ListVolumes",
+			call: func(server *Server, ctx context.Context, organizationID string) error {
+				_, err := server.ListVolumes(ctx, &agentsv1.ListVolumesRequest{
+					OrganizationId: organizationID,
+					PageToken:      undecodablePageToken,
+				})
+				return err
+			},
+		},
+		{
+			name: "ListEnvironments",
+			call: func(server *Server, ctx context.Context, organizationID string) error {
+				_, err := server.ListEnvironments(ctx, &agentsv1.ListEnvironmentsRequest{
+					OrganizationId: organizationID,
+					PageToken:      undecodablePageToken,
+				})
+				return err
+			},
+		},
+		{
+			name: "ListInstances",
+			call: func(server *Server, ctx context.Context, organizationID string) error {
+				_, err := server.ListInstances(ctx, &agentsv1.ListInstancesRequest{
+					OrganizationId: organizationID,
+					PageToken:      undecodablePageToken,
+				})
+				return err
+			},
+		},
+	}
+}
+
+// A caller holding tuples in one organization must not be able to read another
+// one's rows by naming its id.
+func TestListRPCsRefuseAnotherOrganization(t *testing.T) {
+	for _, rpc := range listRPCs() {
+		t.Run(rpc.name, func(t *testing.T) {
+			callerOrganizationID := uuid.New()
+			organizationID := uuid.New()
+			identityID := uuid.New()
+			authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+				organizationPrefix + callerOrganizationID.String(): true,
+			}}
+			server := &Server{authz: authz}
+
+			err := rpc.call(server, identityContext(identityID), organizationID.String())
+			if err == nil {
+				t.Fatal("expected a caller from another organization to be refused")
+			}
+			if strings.Contains(err.Error(), "page_token") {
+				t.Fatalf("expected the refusal to come before anything else, got %v", err)
+			}
+			assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+				organizationRelationTuple(identityID, organizationID, "member"),
+			})
+		})
+	}
+}
+
+// A member of the organization reads it, and is checked for exactly that.
+func TestListRPCsServeAMemberOfTheOrganization(t *testing.T) {
+	for _, rpc := range listRPCs() {
+		t.Run(rpc.name, func(t *testing.T) {
+			organizationID := uuid.New()
+			identityID := uuid.New()
+			authz := &recordingAuthorizationWriter{}
+			server := &Server{authz: authz}
+
+			err := rpc.call(server, identityContext(identityID), organizationID.String())
+			if err == nil || !strings.Contains(err.Error(), "page_token") {
+				t.Fatalf("expected the request to survive authorization and stop on the page token, got %v", err)
+			}
+			assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+				organizationRelationTuple(identityID, organizationID, "member"),
+			})
+		})
+	}
+}
+
+// The Agents Orchestrator reaches these RPCs over the mesh rather than the
+// Gateway and carries no identity by design: it holds no OpenFGA tuples, so a
+// check could only ever refuse it. Breaking this path stops sandboxes and
+// agents from starting.
+func TestListRPCsServeTheInternalCallerWithoutAnIdentity(t *testing.T) {
+	for _, rpc := range listRPCs() {
+		t.Run(rpc.name, func(t *testing.T) {
+			authz := &recordingAuthorizationWriter{}
+			server := &Server{authz: authz}
+
+			err := rpc.call(server, context.Background(), uuid.NewString())
+			if err == nil || !strings.Contains(err.Error(), "page_token") {
+				t.Fatalf("expected the request to survive authorization and stop on the page token, got %v", err)
+			}
+			if len(authz.checks) != 0 {
+				t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+			}
+		})
+	}
+}
+
+// A malformed identity is not an internal caller. It is rejected rather than
+// waved through as one.
+func TestListRPCsRejectAMalformedIdentity(t *testing.T) {
+	for _, rpc := range listRPCs() {
+		t.Run(rpc.name, func(t *testing.T) {
+			authz := &recordingAuthorizationWriter{}
+			server := &Server{authz: authz}
+
+			if err := rpc.call(server, malformedIdentityContext(), uuid.NewString()); err == nil {
+				t.Fatal("expected a malformed identity to be rejected")
+			}
+			if len(authz.checks) != 0 {
+				t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+			}
+		})
+	}
+}
+
+// ListAgents and ListInstances leave organization_id optional so the
+// Orchestrator can read across organizations. A caller presenting an identity
+// must not reach that unscoped path by omitting it.
+func TestListAgentsRequiresAnOrganizationFromAnIdentifiedCaller(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if _, err := server.ListAgents(identityContext(uuid.New()), &agentsv1.ListAgentsRequest{}); err == nil {
+		t.Fatal("expected a request without an organization to be rejected")
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+func TestListInstancesRequiresAnOrganizationFromAnIdentifiedCaller(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if _, err := server.ListInstances(identityContext(uuid.New()), &agentsv1.ListInstancesRequest{}); err == nil {
+		t.Fatal("expected a request without an organization to be rejected")
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+// The Orchestrator's desired-state query names no organization and reads every
+// one of them.
+func TestListInstancesLeavesTheInternalCallerUnscoped(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	scope, err := server.organizationListScope(context.Background(), "")
+	if err != nil {
+		t.Fatalf("organization list scope: %v", err)
+	}
+	if scope != nil {
+		t.Fatalf("expected an unscoped read, got organization %s", scope)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+func TestOrganizationListScopeRejectsAMalformedOrganization(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	if _, err := server.organizationListScope(identityContext(uuid.New()), "not-a-uuid"); err == nil {
+		t.Fatal("expected a malformed organization to be rejected")
+	}
+}

--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -115,14 +115,14 @@ func (s *Server) publishAgentUpdatedForVolume(ctx context.Context, volumeID uuid
 	}
 }
 
-// publishAgentUpdatedForEnv notifies the agent whose configuration the env is
-// part of. An env on an environment is part of no agent's configuration — an
-// environment belongs to an organization — and there is nothing to notify.
-func (s *Server) publishAgentUpdatedForEnv(ctx context.Context, env store.Env) {
-	if env.EnvironmentID != nil {
+// publishAgentUpdatedForConfigTarget notifies the agent whose configuration the
+// row is part of. A row on an environment is part of no agent's configuration —
+// an environment belongs to an organization — and there is nothing to notify.
+func (s *Server) publishAgentUpdatedForConfigTarget(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID, environmentID *uuid.UUID) {
+	if environmentID != nil {
 		return
 	}
-	s.publishAgentUpdatedForTarget(ctx, env.AgentID, env.McpID, env.HookID)
+	s.publishAgentUpdatedForTarget(ctx, agentID, mcpID, hookID)
 }
 
 func (s *Server) publishAgentUpdatedForTarget(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID) {

--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -115,6 +115,16 @@ func (s *Server) publishAgentUpdatedForVolume(ctx context.Context, volumeID uuid
 	}
 }
 
+// publishAgentUpdatedForEnv notifies the agent whose configuration the env is
+// part of. An env on an environment is part of no agent's configuration — an
+// environment belongs to an organization — and there is nothing to notify.
+func (s *Server) publishAgentUpdatedForEnv(ctx context.Context, env store.Env) {
+	if env.EnvironmentID != nil {
+		return
+	}
+	s.publishAgentUpdatedForTarget(ctx, env.AgentID, env.McpID, env.HookID)
+}
+
 func (s *Server) publishAgentUpdatedForTarget(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID) {
 	resolvedID, err := s.resolveAgentID(ctx, agentID, mcpID, hookID)
 	if err != nil {

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -206,11 +206,16 @@ func (s *Server) GetSandbox(ctx context.Context, req *agentsv1.GetSandboxRequest
 	if err != nil {
 		return nil, err
 	}
-	identityID, err := identityUUIDFromContext(ctx)
+	// The Runners service resolves a sandbox-owned workload's owner through this
+	// record, and the Orchestrator reads it while reconciling. Both reach the
+	// service over the mesh carrying no identity, by design — they hold no
+	// OpenFGA tuples. A caller that does present an identity is a user request
+	// and is checked as one.
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if !sandboxReadableWithoutCheck(sandbox, identityID) {
+	if hasIdentity && !sandboxReadableWithoutCheck(sandbox, identityID) {
 		if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, "can_list_all"); err != nil {
 			return nil, err
 		}

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -35,9 +35,9 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	flavorID, err := parseUUID(req.GetFlavorId())
+	runnerID, err := parseUUID(req.GetRunnerId())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "flavor_id: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 	}
 	if err := validateSandboxName(req.GetName()); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
@@ -45,10 +45,14 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	if req.GetImage() == "" {
 		return nil, status.Error(codes.InvalidArgument, "image is required")
 	}
+	// The flavor name is deliberately not checked against the runner's catalog:
+	// it is resolved at workload start so an environment and the runner
+	// configuration naming its flavor can be applied in either order.
 	environment, err := s.store.CreateEnvironment(ctx, organizationID, store.EnvironmentInput{
 		Name:     req.GetName(),
-		FlavorID: flavorID,
 		Image:    req.GetImage(),
+		RunnerID: &runnerID,
+		Flavor:   req.GetFlavor(),
 	})
 	if err != nil {
 		return nil, toStatusError(err)
@@ -73,7 +77,7 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	if req.Name == nil && req.FlavorId == nil && req.Image == nil {
+	if req.Name == nil && req.Image == nil && req.RunnerId == nil && req.Flavor == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	update := store.EnvironmentUpdate{}
@@ -84,12 +88,16 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 		}
 		update.Name = &name
 	}
-	if req.FlavorId != nil {
-		flavorID, err := parseUUID(req.GetFlavorId())
+	if req.RunnerId != nil {
+		runnerID, err := parseUUID(req.GetRunnerId())
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "flavor_id: %v", err)
+			return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 		}
-		update.FlavorID = &flavorID
+		update.RunnerID = &runnerID
+	}
+	if req.Flavor != nil {
+		flavor := req.GetFlavor()
+		update.Flavor = &flavor
 	}
 	if req.Image != nil {
 		image := req.GetImage()

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -216,13 +216,29 @@ func (s *Server) ListSandboxes(ctx context.Context, req *agentsv1.ListSandboxesR
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
-	identityID, err := identityUUIDFromContext(ctx)
+	// The Agents Orchestrator lists an organization's sandboxes to reconcile
+	// them and carries no identity, by design — it holds no OpenFGA tuples and
+	// reaches this RPC over the mesh rather than the Gateway. A caller that does
+	// present an identity is a user request and is filtered and checked as one.
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	filter, err := s.sandboxListFilter(ctx, req, organizationID, identityID)
-	if err != nil {
-		return nil, err
+	var filter store.SandboxFilter
+	if hasIdentity {
+		filter, err = s.sandboxListFilter(ctx, req, organizationID, identityID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		filter = store.SandboxFilter{IncludeTerminated: req.GetIncludeTerminated()}
+		if ownerID := req.GetOwnerId(); ownerID != "" {
+			parsed, parseErr := parseUUID(ownerID)
+			if parseErr != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "owner_id: %v", parseErr)
+			}
+			filter.OwnerID = &parsed
+		}
 	}
 	result, err := s.store.ListSandboxes(ctx, organizationID, filter, req.GetPageSize(), cursor)
 	if err != nil {
@@ -471,6 +487,21 @@ func (s *Server) updateSandboxStatusWithAuthorization(ctx context.Context, id st
 	}
 	s.publishSandboxUpdated(ctx, updated)
 	return updated, nil
+}
+
+// optionalIdentityUUIDFromContext reports the caller's identity when one is
+// present. Absence means an internal caller reaching the service over the mesh
+// rather than through the Gateway; a malformed identity is still an error.
+func optionalIdentityUUIDFromContext(ctx context.Context) (uuid.UUID, bool, error) {
+	identityID, ok := metadataValueFromIncomingContext(ctx, "x-identity-id")
+	if !ok {
+		return uuid.UUID{}, false, nil
+	}
+	id, err := parseUUID(identityID)
+	if err != nil {
+		return uuid.UUID{}, false, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	return id, true, nil
 }
 
 func identityUUIDFromContext(ctx context.Context) (uuid.UUID, error) {

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -125,13 +125,16 @@ func (s *Server) DeleteEnvironment(ctx context.Context, req *agentsv1.DeleteEnvi
 }
 
 func (s *Server) ListEnvironments(ctx context.Context, req *agentsv1.ListEnvironmentsRequest) (*agentsv1.ListEnvironmentsResponse, error) {
-	cursor, err := decodePageCursor(req.GetPageToken())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
-	}
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	if err := s.requireOrganizationListAccess(ctx, organizationID); err != nil {
+		return nil, err
+	}
+	cursor, err := decodePageCursor(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
 	result, err := s.store.ListEnvironments(ctx, organizationID, store.EnvironmentFilter{}, req.GetPageSize(), cursor)
 	if err != nil {

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -207,12 +207,26 @@ func (s *Server) GetSandbox(ctx context.Context, req *agentsv1.GetSandboxRequest
 	if err != nil {
 		return nil, err
 	}
-	if sandbox.OwnerID != identityID {
+	if !sandboxReadableWithoutCheck(sandbox, identityID) {
 		if err := s.requireSandboxRelation(ctx, identityID, sandbox.Meta.ID, "can_list_all"); err != nil {
 			return nil, err
 		}
 	}
 	return &agentsv1.GetSandboxResponse{Sandbox: toProtoSandbox(sandbox)}, nil
+}
+
+// sandboxReadableWithoutCheck covers the two callers that need no tuple: the
+// owner, who holds one anyway, and the sandbox workload itself.
+//
+// A sandbox workload authenticates as its sandbox, and this is the record the
+// platform services it dials — Gateway, LLM Proxy, Tracing — resolve it through
+// to reach its organization and owner. It is not an organization member and
+// holds no tuple of its own, so an OpenFGA check would refuse it and the
+// resolution every one of those services depends on could not happen. Identity
+// equality answers it instead, the same way an agent instance reads its own
+// inbox.
+func sandboxReadableWithoutCheck(sandbox store.Sandbox, identityID uuid.UUID) bool {
+	return sandbox.OwnerID == identityID || sandbox.Meta.ID == identityID
 }
 
 func (s *Server) ListSandboxes(ctx context.Context, req *agentsv1.ListSandboxesRequest) (*agentsv1.ListSandboxesResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -817,6 +817,12 @@ func (s *Server) CreateImagePullSecretAttachment(ctx context.Context, req *agent
 			return nil, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
 		}
 		input.HookID = &id
+	case *agentsv1.CreateImagePullSecretAttachmentRequest_EnvironmentId:
+		id, err := parseUUID(target.EnvironmentId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		input.EnvironmentID = &id
 	default:
 		return nil, status.Error(codes.InvalidArgument, "target must be specified")
 	}
@@ -825,7 +831,7 @@ func (s *Server) CreateImagePullSecretAttachment(ctx context.Context, req *agent
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, attachment.AgentID, attachment.McpID, attachment.HookID)
+	s.publishAgentUpdatedForConfigTarget(ctx, attachment.AgentID, attachment.McpID, attachment.HookID, attachment.EnvironmentID)
 	return &agentsv1.CreateImagePullSecretAttachmentResponse{ImagePullSecretAttachment: toProtoImagePullSecretAttachment(attachment)}, nil
 }
 
@@ -853,7 +859,7 @@ func (s *Server) DeleteImagePullSecretAttachment(ctx context.Context, req *agent
 	if err := s.store.DeleteImagePullSecretAttachment(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, attachment.AgentID, attachment.McpID, attachment.HookID)
+	s.publishAgentUpdatedForConfigTarget(ctx, attachment.AgentID, attachment.McpID, attachment.HookID, attachment.EnvironmentID)
 	return &agentsv1.DeleteImagePullSecretAttachmentResponse{}, nil
 }
 
@@ -862,7 +868,6 @@ func (s *Server) ListImagePullSecretAttachments(ctx context.Context, req *agents
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
-
 	hasFilter := false
 	filter := store.ImagePullSecretAttachmentFilter{}
 	if req.GetImagePullSecretId() != "" {
@@ -896,6 +901,14 @@ func (s *Server) ListImagePullSecretAttachments(ctx context.Context, req *agents
 			return nil, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
 		}
 		filter.HookID = &hookID
+	}
+	if req.GetEnvironmentId() != "" {
+		hasFilter = true
+		environmentID, err := parseUUID(req.GetEnvironmentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		filter.EnvironmentID = &environmentID
 	}
 	if !hasFilter {
 		return nil, status.Error(codes.InvalidArgument, "at least one filter must be provided")
@@ -1284,7 +1297,7 @@ func (s *Server) CreateEnv(ctx context.Context, req *agentsv1.CreateEnvRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForEnv(ctx, env)
+	s.publishAgentUpdatedForConfigTarget(ctx, env.AgentID, env.McpID, env.HookID, env.EnvironmentID)
 	return &agentsv1.CreateEnvResponse{Env: toProtoEnv(env)}, nil
 }
 
@@ -1337,7 +1350,7 @@ func (s *Server) UpdateEnv(ctx context.Context, req *agentsv1.UpdateEnvRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForEnv(ctx, env)
+	s.publishAgentUpdatedForConfigTarget(ctx, env.AgentID, env.McpID, env.HookID, env.EnvironmentID)
 	return &agentsv1.UpdateEnvResponse{Env: toProtoEnv(env)}, nil
 }
 
@@ -1353,7 +1366,7 @@ func (s *Server) DeleteEnv(ctx context.Context, req *agentsv1.DeleteEnvRequest) 
 	if err := s.store.DeleteEnv(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForEnv(ctx, env)
+	s.publishAgentUpdatedForConfigTarget(ctx, env.AgentID, env.McpID, env.HookID, env.EnvironmentID)
 	return &agentsv1.DeleteEnvResponse{}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -868,50 +868,9 @@ func (s *Server) ListImagePullSecretAttachments(ctx context.Context, req *agents
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
-	hasFilter := false
-	filter := store.ImagePullSecretAttachmentFilter{}
-	if req.GetImagePullSecretId() != "" {
-		hasFilter = true
-		imagePullSecretID, err := parseUUID(req.GetImagePullSecretId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "image_pull_secret_id: %v", err)
-		}
-		filter.ImagePullSecretID = &imagePullSecretID
-	}
-	if req.GetAgentId() != "" {
-		hasFilter = true
-		agentID, err := parseUUID(req.GetAgentId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
-		}
-		filter.AgentID = &agentID
-	}
-	if req.GetMcpId() != "" {
-		hasFilter = true
-		mcpID, err := parseUUID(req.GetMcpId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
-		}
-		filter.McpID = &mcpID
-	}
-	if req.GetHookId() != "" {
-		hasFilter = true
-		hookID, err := parseUUID(req.GetHookId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
-		}
-		filter.HookID = &hookID
-	}
-	if req.GetEnvironmentId() != "" {
-		hasFilter = true
-		environmentID, err := parseUUID(req.GetEnvironmentId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
-		}
-		filter.EnvironmentID = &environmentID
-	}
-	if !hasFilter {
-		return nil, status.Error(codes.InvalidArgument, "at least one filter must be provided")
+	filter, err := s.imagePullSecretAttachmentListFilter(ctx, req)
+	if err != nil {
+		return nil, err
 	}
 
 	result, err := s.store.ListImagePullSecretAttachments(ctx, filter, req.GetPageSize(), cursor)
@@ -920,6 +879,81 @@ func (s *Server) ListImagePullSecretAttachments(ctx context.Context, req *agents
 	}
 	attachments, nextToken := mapListResult(result.ImagePullSecretAttachments, result.NextCursor, toProtoImagePullSecretAttachment)
 	return &agentsv1.ListImagePullSecretAttachmentsResponse{ImagePullSecretAttachments: attachments, NextPageToken: nextToken}, nil
+}
+
+// imagePullSecretAttachmentListFilter authorizes the read and narrows it.
+//
+// The Agents Orchestrator lists an environment's image pull secret attachments
+// while assembling a sandbox workload and carries no identity, by design — it
+// holds no OpenFGA tuples and reaches this RPC over the mesh rather than the
+// Gateway. A caller that does present an identity is a user request: it names
+// the organization it is reading and must be a member of it. The target ids
+// only narrow the result further; an attachment is a reference to a registry
+// credential, and which organization's credentials are being read is settled by
+// the organization, not by them.
+func (s *Server) imagePullSecretAttachmentListFilter(ctx context.Context, req *agentsv1.ListImagePullSecretAttachmentsRequest) (store.ImagePullSecretAttachmentFilter, error) {
+	filter := store.ImagePullSecretAttachmentFilter{}
+	if req.GetImagePullSecretId() != "" {
+		imagePullSecretID, err := parseUUID(req.GetImagePullSecretId())
+		if err != nil {
+			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "image_pull_secret_id: %v", err)
+		}
+		filter.ImagePullSecretID = &imagePullSecretID
+	}
+	if req.GetAgentId() != "" {
+		agentID, err := parseUUID(req.GetAgentId())
+		if err != nil {
+			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+		}
+		filter.AgentID = &agentID
+	}
+	if req.GetMcpId() != "" {
+		mcpID, err := parseUUID(req.GetMcpId())
+		if err != nil {
+			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		filter.McpID = &mcpID
+	}
+	if req.GetHookId() != "" {
+		hookID, err := parseUUID(req.GetHookId())
+		if err != nil {
+			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
+		}
+		filter.HookID = &hookID
+	}
+	if req.GetEnvironmentId() != "" {
+		environmentID, err := parseUUID(req.GetEnvironmentId())
+		if err != nil {
+			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		filter.EnvironmentID = &environmentID
+	}
+
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return store.ImagePullSecretAttachmentFilter{}, err
+	}
+	if !hasIdentity {
+		if req.GetOrganizationId() == "" {
+			return filter, nil
+		}
+		organizationID, err := parseUUID(req.GetOrganizationId())
+		if err != nil {
+			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		filter.OrganizationID = &organizationID
+		return filter, nil
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
+		return store.ImagePullSecretAttachmentFilter{}, err
+	}
+	filter.OrganizationID = &organizationID
+	return filter, nil
 }
 
 func (s *Server) CreateMcp(ctx context.Context, req *agentsv1.CreateMcpRequest) (*agentsv1.CreateMcpResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1256,6 +1256,12 @@ func (s *Server) CreateEnv(ctx context.Context, req *agentsv1.CreateEnvRequest) 
 			return nil, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
 		}
 		input.HookID = &id
+	case *agentsv1.CreateEnvRequest_EnvironmentId:
+		id, err := parseUUID(target.EnvironmentId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		input.EnvironmentID = &id
 	default:
 		return nil, status.Error(codes.InvalidArgument, "target must be specified")
 	}
@@ -1278,7 +1284,7 @@ func (s *Server) CreateEnv(ctx context.Context, req *agentsv1.CreateEnvRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, env.AgentID, env.McpID, env.HookID)
+	s.publishAgentUpdatedForEnv(ctx, env)
 	return &agentsv1.CreateEnvResponse{Env: toProtoEnv(env)}, nil
 }
 
@@ -1331,7 +1337,7 @@ func (s *Server) UpdateEnv(ctx context.Context, req *agentsv1.UpdateEnvRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, env.AgentID, env.McpID, env.HookID)
+	s.publishAgentUpdatedForEnv(ctx, env)
 	return &agentsv1.UpdateEnvResponse{Env: toProtoEnv(env)}, nil
 }
 
@@ -1347,7 +1353,7 @@ func (s *Server) DeleteEnv(ctx context.Context, req *agentsv1.DeleteEnvRequest) 
 	if err := s.store.DeleteEnv(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, env.AgentID, env.McpID, env.HookID)
+	s.publishAgentUpdatedForEnv(ctx, env)
 	return &agentsv1.DeleteEnvResponse{}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -547,14 +547,9 @@ func (s *Server) ListMyAgentRoles(ctx context.Context, req *agentsv1.ListMyAgent
 }
 
 func (s *Server) ListAgents(ctx context.Context, req *agentsv1.ListAgentsRequest) (*agentsv1.ListAgentsResponse, error) {
-	var organizationID *uuid.UUID
-	organizationValue := req.GetOrganizationId()
-	if organizationValue != "" {
-		parsedOrganizationID, err := parseUUID(organizationValue)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		organizationID = &parsedOrganizationID
+	organizationID, err := s.organizationListScope(ctx, req.GetOrganizationId())
+	if err != nil {
+		return nil, err
 	}
 	cursor, err := decodePageCursor(req.GetPageToken())
 	if err != nil {
@@ -660,6 +655,9 @@ func (s *Server) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesReque
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	if err := s.requireOrganizationListAccess(ctx, organizationID); err != nil {
+		return nil, err
 	}
 	cursor, err := decodePageCursor(req.GetPageToken())
 	if err != nil {
@@ -929,30 +927,11 @@ func (s *Server) imagePullSecretAttachmentListFilter(ctx context.Context, req *a
 		filter.EnvironmentID = &environmentID
 	}
 
-	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	organizationID, err := s.organizationListScope(ctx, req.GetOrganizationId())
 	if err != nil {
 		return store.ImagePullSecretAttachmentFilter{}, err
 	}
-	if !hasIdentity {
-		if req.GetOrganizationId() == "" {
-			return filter, nil
-		}
-		organizationID, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		filter.OrganizationID = &organizationID
-		return filter, nil
-	}
-
-	organizationID, err := parseUUID(req.GetOrganizationId())
-	if err != nil {
-		return store.ImagePullSecretAttachmentFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-	}
-	if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
-		return store.ImagePullSecretAttachmentFilter{}, err
-	}
-	filter.OrganizationID = &organizationID
+	filter.OrganizationID = organizationID
 	return filter, nil
 }
 
@@ -1462,30 +1441,11 @@ func (s *Server) envListFilter(ctx context.Context, req *agentsv1.ListEnvsReques
 		filter.EnvironmentID = &environmentID
 	}
 
-	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	organizationID, err := s.organizationListScope(ctx, req.GetOrganizationId())
 	if err != nil {
 		return store.EnvFilter{}, err
 	}
-	if !hasIdentity {
-		if req.GetOrganizationId() == "" {
-			return filter, nil
-		}
-		organizationID, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		filter.OrganizationID = &organizationID
-		return filter, nil
-	}
-
-	organizationID, err := parseUUID(req.GetOrganizationId())
-	if err != nil {
-		return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-	}
-	if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
-		return store.EnvFilter{}, err
-	}
-	filter.OrganizationID = &organizationID
+	filter.OrganizationID = organizationID
 	return filter, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1362,35 +1362,9 @@ func (s *Server) ListEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest) (*
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
-
-	hasFilter := false
-	filter := store.EnvFilter{}
-	if req.GetAgentId() != "" {
-		hasFilter = true
-		agentID, err := parseUUID(req.GetAgentId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
-		}
-		filter.AgentID = &agentID
-	}
-	if req.GetMcpId() != "" {
-		hasFilter = true
-		mcpID, err := parseUUID(req.GetMcpId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
-		}
-		filter.McpID = &mcpID
-	}
-	if req.GetHookId() != "" {
-		hasFilter = true
-		hookID, err := parseUUID(req.GetHookId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
-		}
-		filter.HookID = &hookID
-	}
-	if !hasFilter {
-		return nil, status.Error(codes.InvalidArgument, "at least one filter must be provided")
+	filter, err := s.envListFilter(ctx, req)
+	if err != nil {
+		return nil, err
 	}
 
 	result, err := s.store.ListEnvs(ctx, filter, req.GetPageSize(), cursor)
@@ -1399,6 +1373,73 @@ func (s *Server) ListEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest) (*
 	}
 	envs, nextToken := mapListResult(result.Envs, result.NextCursor, toProtoEnv)
 	return &agentsv1.ListEnvsResponse{Envs: envs, NextPageToken: nextToken}, nil
+}
+
+// envListFilter authorizes the read and narrows it.
+//
+// The Agents Orchestrator lists an environment's envs while assembling a
+// sandbox workload and carries no identity, by design — it holds no OpenFGA
+// tuples and reaches this RPC over the mesh rather than the Gateway. A caller
+// that does present an identity is a user request: it names the organization it
+// is reading and must be a member of it. The target ids only narrow the result
+// further; an env is a reference to a secret, and which organization's secrets
+// are being read is settled by the organization, not by them.
+func (s *Server) envListFilter(ctx context.Context, req *agentsv1.ListEnvsRequest) (store.EnvFilter, error) {
+	filter := store.EnvFilter{}
+	if req.GetAgentId() != "" {
+		agentID, err := parseUUID(req.GetAgentId())
+		if err != nil {
+			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+		}
+		filter.AgentID = &agentID
+	}
+	if req.GetMcpId() != "" {
+		mcpID, err := parseUUID(req.GetMcpId())
+		if err != nil {
+			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		filter.McpID = &mcpID
+	}
+	if req.GetHookId() != "" {
+		hookID, err := parseUUID(req.GetHookId())
+		if err != nil {
+			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "hook_id: %v", err)
+		}
+		filter.HookID = &hookID
+	}
+	if req.GetEnvironmentId() != "" {
+		environmentID, err := parseUUID(req.GetEnvironmentId())
+		if err != nil {
+			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		filter.EnvironmentID = &environmentID
+	}
+
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return store.EnvFilter{}, err
+	}
+	if !hasIdentity {
+		if req.GetOrganizationId() == "" {
+			return filter, nil
+		}
+		organizationID, err := parseUUID(req.GetOrganizationId())
+		if err != nil {
+			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		filter.OrganizationID = &organizationID
+		return filter, nil
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	if err := s.requireOrganizationMember(ctx, identityID, organizationID); err != nil {
+		return store.EnvFilter{}, err
+	}
+	filter.OrganizationID = &organizationID
+	return filter, nil
 }
 
 func (s *Server) CreateInitScript(ctx context.Context, req *agentsv1.CreateInitScriptRequest) (*agentsv1.CreateInitScriptResponse, error) {

--- a/internal/store/agent_helpers.go
+++ b/internal/store/agent_helpers.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -43,6 +44,58 @@ func resolveAgentID(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, mcpID *u
 		return agentIDForHook(ctx, tx, *hookID)
 	}
 	return uuid.UUID{}, fmt.Errorf("missing target identifier")
+}
+
+// touchEnvAgent marks the agent an env belongs to as updated so the agent's
+// workload is reassembled. An env targeting an environment belongs to no agent:
+// an environment is an organization's, and there is nothing to touch.
+func touchEnvAgent(ctx context.Context, tx pgx.Tx, env Env) error {
+	if env.EnvironmentID != nil {
+		return nil
+	}
+	agentID, err := resolveAgentID(ctx, tx, env.AgentID, env.McpID, env.HookID)
+	if err != nil {
+		return err
+	}
+	return touchAgentUpdatedAt(ctx, tx, agentID)
+}
+
+// organizationIDForEnvTarget reports the organization an env target belongs to.
+// An agent and an environment hold one directly; an mcp and a hook reach it
+// through their agent.
+func organizationIDForEnvTarget(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID, environmentID *uuid.UUID) (uuid.UUID, error) {
+	if environmentID != nil {
+		return organizationIDForEnvironment(ctx, tx, *environmentID)
+	}
+	resolvedAgentID, err := resolveAgentID(ctx, tx, agentID, mcpID, hookID)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return organizationIDForAgent(ctx, tx, resolvedAgentID)
+}
+
+func organizationIDForAgent(ctx context.Context, tx pgx.Tx, agentID uuid.UUID) (uuid.UUID, error) {
+	var organizationID uuid.UUID
+	row := tx.QueryRow(ctx, "SELECT organization_id FROM agents WHERE id = $1", agentID)
+	if err := row.Scan(&organizationID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.UUID{}, NotFound("agent")
+		}
+		return uuid.UUID{}, err
+	}
+	return organizationID, nil
+}
+
+func organizationIDForEnvironment(ctx context.Context, tx pgx.Tx, environmentID uuid.UUID) (uuid.UUID, error) {
+	var organizationID uuid.UUID
+	row := tx.QueryRow(ctx, "SELECT organization_id FROM environments WHERE id = $1", environmentID)
+	if err := row.Scan(&organizationID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.UUID{}, NotFound("environment")
+		}
+		return uuid.UUID{}, err
+	}
+	return organizationID, nil
 }
 
 func agentIDForMcp(ctx context.Context, tx pgx.Tx, mcpID uuid.UUID) (uuid.UUID, error) {

--- a/internal/store/agent_helpers.go
+++ b/internal/store/agent_helpers.go
@@ -46,24 +46,24 @@ func resolveAgentID(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, mcpID *u
 	return uuid.UUID{}, fmt.Errorf("missing target identifier")
 }
 
-// touchEnvAgent marks the agent an env belongs to as updated so the agent's
-// workload is reassembled. An env targeting an environment belongs to no agent:
+// touchTargetAgent marks the agent a row belongs to as updated so the agent's
+// workload is reassembled. A row targeting an environment belongs to no agent:
 // an environment is an organization's, and there is nothing to touch.
-func touchEnvAgent(ctx context.Context, tx pgx.Tx, env Env) error {
-	if env.EnvironmentID != nil {
+func touchTargetAgent(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID, environmentID *uuid.UUID) error {
+	if environmentID != nil {
 		return nil
 	}
-	agentID, err := resolveAgentID(ctx, tx, env.AgentID, env.McpID, env.HookID)
+	resolvedAgentID, err := resolveAgentID(ctx, tx, agentID, mcpID, hookID)
 	if err != nil {
 		return err
 	}
-	return touchAgentUpdatedAt(ctx, tx, agentID)
+	return touchAgentUpdatedAt(ctx, tx, resolvedAgentID)
 }
 
-// organizationIDForEnvTarget reports the organization an env target belongs to.
-// An agent and an environment hold one directly; an mcp and a hook reach it
+// organizationIDForTarget reports the organization a target belongs to. An
+// agent and an environment hold one directly; an mcp and a hook reach it
 // through their agent.
-func organizationIDForEnvTarget(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID, environmentID *uuid.UUID) (uuid.UUID, error) {
+func organizationIDForTarget(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, mcpID *uuid.UUID, hookID *uuid.UUID, environmentID *uuid.UUID) (uuid.UUID, error) {
 	if environmentID != nil {
 		return organizationIDForEnvironment(ctx, tx, *environmentID)
 	}

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -12,13 +12,14 @@ import (
 
 func (s *Store) CreateEnvironment(ctx context.Context, organizationID uuid.UUID, input EnvironmentInput) (Environment, error) {
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO environments (organization_id, name, flavor_id, image)
-		 VALUES ($1, $2, $3, $4)
+		fmt.Sprintf(`INSERT INTO environments (organization_id, name, image, runner_id, flavor)
+		 VALUES ($1, $2, $3, $4, $5)
 		 RETURNING %s`, environmentColumns),
 		organizationID,
 		input.Name,
-		input.FlavorID,
 		input.Image,
+		input.RunnerID,
+		input.Flavor,
 	)
 	environment, err := scanEnvironment(row)
 	if err != nil {
@@ -51,11 +52,14 @@ func (s *Store) UpdateEnvironment(ctx context.Context, id uuid.UUID, update Envi
 	if update.Name != nil {
 		builder.add("name", *update.Name)
 	}
-	if update.FlavorID != nil {
-		builder.add("flavor_id", *update.FlavorID)
-	}
 	if update.Image != nil {
 		builder.add("image", *update.Image)
+	}
+	if update.RunnerID != nil {
+		builder.add("runner_id", *update.RunnerID)
+	}
+	if update.Flavor != nil {
+		builder.add("flavor", *update.Flavor)
 	}
 	if builder.empty() {
 		return Environment{}, fmt.Errorf("environment update requires at least one field")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,7 +17,7 @@ const (
 	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, created_at, updated_at`
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
-	imagePullSecretAttachmentColumns = `id, image_pull_secret_id, agent_id, mcp_id, hook_id, created_at, updated_at`
+	imagePullSecretAttachmentColumns = `id, organization_id, image_pull_secret_id, agent_id, mcp_id, hook_id, environment_id, created_at, updated_at`
 	environmentColumns               = `id, organization_id, name, flavor_id, image, flavor_name, runner_id, flavor, created_at, updated_at`
 	sandboxColumns                   = `id, organization_id, name, environment_id, owner_id, status, idle_timeout, ttl, last_session_at, environment_name, workload_id, created_at, updated_at`
 	mcpColumns                       = `id, agent_id, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, created_at, updated_at`
@@ -159,12 +159,15 @@ func scanImagePullSecretAttachment(row pgx.Row) (ImagePullSecretAttachment, erro
 	var agentID pgtype.UUID
 	var mcpID pgtype.UUID
 	var hookID pgtype.UUID
+	var environmentID pgtype.UUID
 	if err := row.Scan(
 		&attachment.Meta.ID,
+		&attachment.OrganizationID,
 		&attachment.ImagePullSecretID,
 		&agentID,
 		&mcpID,
 		&hookID,
+		&environmentID,
 		&attachment.Meta.CreatedAt,
 		&attachment.Meta.UpdatedAt,
 	); err != nil {
@@ -173,6 +176,7 @@ func scanImagePullSecretAttachment(row pgx.Row) (ImagePullSecretAttachment, erro
 	attachment.AgentID = uuidPtrFromPg(agentID)
 	attachment.McpID = uuidPtrFromPg(mcpID)
 	attachment.HookID = uuidPtrFromPg(hookID)
+	attachment.EnvironmentID = uuidPtrFromPg(environmentID)
 	return attachment, nil
 }
 
@@ -813,14 +817,22 @@ func (s *Store) ListVolumeAttachments(ctx context.Context, filter VolumeAttachme
 
 func (s *Store) CreateImagePullSecretAttachment(ctx context.Context, input ImagePullSecretAttachmentInput) (ImagePullSecretAttachment, error) {
 	return withTx(ctx, s.pool, func(tx pgx.Tx) (ImagePullSecretAttachment, error) {
+		// A caller names only the target, so the organization the row is scoped
+		// by is derived from it, in the same transaction that writes the row.
+		organizationID, err := organizationIDForTarget(ctx, tx, input.AgentID, input.McpID, input.HookID, input.EnvironmentID)
+		if err != nil {
+			return ImagePullSecretAttachment{}, err
+		}
 		row := tx.QueryRow(ctx,
-			fmt.Sprintf(`INSERT INTO image_pull_secret_attachments (image_pull_secret_id, agent_id, mcp_id, hook_id)
-		 VALUES ($1, $2, $3, $4)
+			fmt.Sprintf(`INSERT INTO image_pull_secret_attachments (organization_id, image_pull_secret_id, agent_id, mcp_id, hook_id, environment_id)
+		 VALUES ($1, $2, $3, $4, $5, $6)
 		 RETURNING %s`, imagePullSecretAttachmentColumns),
+			organizationID,
 			input.ImagePullSecretID,
 			input.AgentID,
 			input.McpID,
 			input.HookID,
+			input.EnvironmentID,
 		)
 		attachment, err := scanImagePullSecretAttachment(row)
 		if err != nil {
@@ -835,11 +847,7 @@ func (s *Store) CreateImagePullSecretAttachment(ctx context.Context, input Image
 			}
 			return ImagePullSecretAttachment{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, attachment.AgentID, attachment.McpID, attachment.HookID)
-		if err != nil {
-			return ImagePullSecretAttachment{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, attachment.AgentID, attachment.McpID, attachment.HookID, attachment.EnvironmentID); err != nil {
 			return ImagePullSecretAttachment{}, err
 		}
 		return attachment, nil
@@ -874,11 +882,7 @@ func (s *Store) DeleteImagePullSecretAttachment(ctx context.Context, id uuid.UUI
 			}
 			return struct{}{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, attachment.AgentID, attachment.McpID, attachment.HookID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, attachment.AgentID, attachment.McpID, attachment.HookID, attachment.EnvironmentID); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -889,6 +893,9 @@ func (s *Store) DeleteImagePullSecretAttachment(ctx context.Context, id uuid.UUI
 func (s *Store) ListImagePullSecretAttachments(ctx context.Context, filter ImagePullSecretAttachmentFilter, pageSize int32, cursor *PageCursor) (ImagePullSecretAttachmentListResult, error) {
 	clauses := []string{}
 	args := []any{}
+	if filter.OrganizationID != nil {
+		clauses, args = appendClause(clauses, args, "organization_id = $%d", *filter.OrganizationID)
+	}
 	if filter.ImagePullSecretID != nil {
 		clauses, args = appendClause(clauses, args, "image_pull_secret_id = $%d", *filter.ImagePullSecretID)
 	}
@@ -900,6 +907,9 @@ func (s *Store) ListImagePullSecretAttachments(ctx context.Context, filter Image
 	}
 	if filter.HookID != nil {
 		clauses, args = appendClause(clauses, args, "hook_id = $%d", *filter.HookID)
+	}
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
 	}
 
 	attachments, nextCursor, err := listEntities(ctx, s.pool,
@@ -1307,7 +1317,7 @@ func (s *Store) CreateEnv(ctx context.Context, input EnvInput) (Env, error) {
 	return withTx(ctx, s.pool, func(tx pgx.Tx) (Env, error) {
 		// A caller names only the target, so the organization the row is scoped
 		// by is derived from it, in the same transaction that writes the row.
-		organizationID, err := organizationIDForEnvTarget(ctx, tx, input.AgentID, input.McpID, input.HookID, input.EnvironmentID)
+		organizationID, err := organizationIDForTarget(ctx, tx, input.AgentID, input.McpID, input.HookID, input.EnvironmentID)
 		if err != nil {
 			return Env{}, err
 		}
@@ -1333,7 +1343,7 @@ func (s *Store) CreateEnv(ctx context.Context, input EnvInput) (Env, error) {
 			}
 			return Env{}, err
 		}
-		if err := touchEnvAgent(ctx, tx, env); err != nil {
+		if err := touchTargetAgent(ctx, tx, env.AgentID, env.McpID, env.HookID, env.EnvironmentID); err != nil {
 			return Env{}, err
 		}
 		return env, nil
@@ -1385,7 +1395,7 @@ func (s *Store) UpdateEnv(ctx context.Context, id uuid.UUID, update EnvUpdate) (
 			}
 			return Env{}, err
 		}
-		if err := touchEnvAgent(ctx, tx, env); err != nil {
+		if err := touchTargetAgent(ctx, tx, env.AgentID, env.McpID, env.HookID, env.EnvironmentID); err != nil {
 			return Env{}, err
 		}
 		return env, nil
@@ -1405,7 +1415,7 @@ func (s *Store) DeleteEnv(ctx context.Context, id uuid.UUID) error {
 			}
 			return struct{}{}, err
 		}
-		if err := touchEnvAgent(ctx, tx, env); err != nil {
+		if err := touchTargetAgent(ctx, tx, env.AgentID, env.McpID, env.HookID, env.EnvironmentID); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,7 +23,7 @@ const (
 	mcpColumns                       = `id, agent_id, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, created_at, updated_at`
 	skillColumns                     = `id, agent_id, name, body, description, created_at, updated_at`
 	hookColumns                      = `id, agent_id, event, "function", image, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, created_at, updated_at`
-	envColumns                       = `id, name, description, agent_id, mcp_id, hook_id, value, secret_id, created_at, updated_at`
+	envColumns                       = `id, organization_id, name, description, agent_id, mcp_id, hook_id, environment_id, value, secret_id, created_at, updated_at`
 	initScriptColumns                = `id, script, description, agent_id, mcp_id, hook_id, created_at, updated_at`
 )
 
@@ -286,15 +286,18 @@ func scanEnv(row pgx.Row) (Env, error) {
 	var agentID pgtype.UUID
 	var mcpID pgtype.UUID
 	var hookID pgtype.UUID
+	var environmentID pgtype.UUID
 	var value pgtype.Text
 	var secretID pgtype.UUID
 	if err := row.Scan(
 		&env.Meta.ID,
+		&env.OrganizationID,
 		&env.Name,
 		&env.Description,
 		&agentID,
 		&mcpID,
 		&hookID,
+		&environmentID,
 		&value,
 		&secretID,
 		&env.Meta.CreatedAt,
@@ -305,6 +308,7 @@ func scanEnv(row pgx.Row) (Env, error) {
 	env.AgentID = uuidPtrFromPg(agentID)
 	env.McpID = uuidPtrFromPg(mcpID)
 	env.HookID = uuidPtrFromPg(hookID)
+	env.EnvironmentID = uuidPtrFromPg(environmentID)
 	env.Value = stringPtrFromPg(value)
 	env.SecretID = uuidPtrFromPg(secretID)
 	return env, nil
@@ -1301,15 +1305,23 @@ func (s *Store) ListHooks(ctx context.Context, filter HookFilter, pageSize int32
 
 func (s *Store) CreateEnv(ctx context.Context, input EnvInput) (Env, error) {
 	return withTx(ctx, s.pool, func(tx pgx.Tx) (Env, error) {
+		// A caller names only the target, so the organization the row is scoped
+		// by is derived from it, in the same transaction that writes the row.
+		organizationID, err := organizationIDForEnvTarget(ctx, tx, input.AgentID, input.McpID, input.HookID, input.EnvironmentID)
+		if err != nil {
+			return Env{}, err
+		}
 		row := tx.QueryRow(ctx,
-			fmt.Sprintf(`INSERT INTO envs (name, description, agent_id, mcp_id, hook_id, value, secret_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+			fmt.Sprintf(`INSERT INTO envs (organization_id, name, description, agent_id, mcp_id, hook_id, environment_id, value, secret_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING %s`, envColumns),
+			organizationID,
 			input.Name,
 			input.Description,
 			input.AgentID,
 			input.McpID,
 			input.HookID,
+			input.EnvironmentID,
 			input.Value,
 			input.SecretID,
 		)
@@ -1321,11 +1333,7 @@ func (s *Store) CreateEnv(ctx context.Context, input EnvInput) (Env, error) {
 			}
 			return Env{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, env.AgentID, env.McpID, env.HookID)
-		if err != nil {
-			return Env{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchEnvAgent(ctx, tx, env); err != nil {
 			return Env{}, err
 		}
 		return env, nil
@@ -1377,11 +1385,7 @@ func (s *Store) UpdateEnv(ctx context.Context, id uuid.UUID, update EnvUpdate) (
 			}
 			return Env{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, env.AgentID, env.McpID, env.HookID)
-		if err != nil {
-			return Env{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchEnvAgent(ctx, tx, env); err != nil {
 			return Env{}, err
 		}
 		return env, nil
@@ -1401,11 +1405,7 @@ func (s *Store) DeleteEnv(ctx context.Context, id uuid.UUID) error {
 			}
 			return struct{}{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, env.AgentID, env.McpID, env.HookID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchEnvAgent(ctx, tx, env); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -1416,6 +1416,9 @@ func (s *Store) DeleteEnv(ctx context.Context, id uuid.UUID) error {
 func (s *Store) ListEnvs(ctx context.Context, filter EnvFilter, pageSize int32, cursor *PageCursor) (EnvListResult, error) {
 	clauses := []string{}
 	args := []any{}
+	if filter.OrganizationID != nil {
+		clauses, args = appendClause(clauses, args, "organization_id = $%d", *filter.OrganizationID)
+	}
 	if filter.AgentID != nil {
 		clauses, args = appendClause(clauses, args, "agent_id = $%d", *filter.AgentID)
 	}
@@ -1424,6 +1427,9 @@ func (s *Store) ListEnvs(ctx context.Context, filter EnvFilter, pageSize int32, 
 	}
 	if filter.HookID != nil {
 		clauses, args = appendClause(clauses, args, "hook_id = $%d", *filter.HookID)
+	}
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
 	}
 
 	envs, nextCursor, err := listEntities(ctx, s.pool,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ const (
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, image_pull_secret_id, agent_id, mcp_id, hook_id, created_at, updated_at`
-	environmentColumns               = `id, organization_id, name, flavor_id, image, flavor_name, created_at, updated_at`
+	environmentColumns               = `id, organization_id, name, flavor_id, image, flavor_name, runner_id, flavor, created_at, updated_at`
 	sandboxColumns                   = `id, organization_id, name, environment_id, owner_id, status, idle_timeout, ttl, last_session_at, environment_name, workload_id, created_at, updated_at`
 	mcpColumns                       = `id, agent_id, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, created_at, updated_at`
 	skillColumns                     = `id, agent_id, name, body, description, created_at, updated_at`
@@ -185,6 +185,8 @@ func scanEnvironment(row pgx.Row) (Environment, error) {
 		&environment.FlavorID,
 		&environment.Image,
 		&environment.FlavorName,
+		&environment.RunnerID,
+		&environment.Flavor,
 		&environment.Meta.CreatedAt,
 		&environment.Meta.UpdatedAt,
 	); err != nil {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -162,10 +162,12 @@ type VolumeAttachment struct {
 
 type ImagePullSecretAttachment struct {
 	Meta              EntityMeta
+	OrganizationID    uuid.UUID
 	ImagePullSecretID uuid.UUID
 	AgentID           *uuid.UUID
 	McpID             *uuid.UUID
 	HookID            *uuid.UUID
+	EnvironmentID     *uuid.UUID
 }
 
 type Mcp struct {
@@ -305,6 +307,7 @@ type ImagePullSecretAttachmentInput struct {
 	AgentID           *uuid.UUID
 	McpID             *uuid.UUID
 	HookID            *uuid.UUID
+	EnvironmentID     *uuid.UUID
 }
 
 type McpInput struct {
@@ -425,11 +428,18 @@ type VolumeAttachmentFilter struct {
 	HookID   *uuid.UUID
 }
 
+// ImagePullSecretAttachmentFilter narrows a list of attachments.
+// OrganizationID is what keeps a list inside one tenant; it is a pointer
+// because the Agents Orchestrator lists an environment's attachments over the
+// mesh without naming an organization, and the remaining fields narrow within
+// whatever scope results.
 type ImagePullSecretAttachmentFilter struct {
+	OrganizationID    *uuid.UUID
 	ImagePullSecretID *uuid.UUID
 	AgentID           *uuid.UUID
 	McpID             *uuid.UUID
 	HookID            *uuid.UUID
+	EnvironmentID     *uuid.UUID
 }
 
 type McpFilter struct {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -211,9 +211,15 @@ type Environment struct {
 	Meta           EntityMeta
 	OrganizationID uuid.UUID
 	Name           string
-	FlavorID       uuid.UUID
 	Image          string
-	FlavorName     string
+	// RunnerID is where workloads for this environment are placed, and Flavor
+	// names an entry in that runner's reported catalog. Flavor is resolved at
+	// workload start, not here.
+	RunnerID *uuid.UUID
+	Flavor   string
+	// Superseded by RunnerID and Flavor; retained for callers still reading it.
+	FlavorID   *uuid.UUID
+	FlavorName string
 }
 
 type Sandbox struct {
@@ -377,14 +383,16 @@ type InitScriptUpdate struct {
 
 type EnvironmentInput struct {
 	Name     string
-	FlavorID uuid.UUID
 	Image    string
+	RunnerID *uuid.UUID
+	Flavor   string
 }
 
 type EnvironmentUpdate struct {
 	Name     *string
-	FlavorID *uuid.UUID
 	Image    *string
+	RunnerID *uuid.UUID
+	Flavor   *string
 }
 
 type SandboxInput struct {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -197,14 +197,16 @@ type Hook struct {
 }
 
 type Env struct {
-	Meta        EntityMeta
-	Name        string
-	Description string
-	AgentID     *uuid.UUID
-	McpID       *uuid.UUID
-	HookID      *uuid.UUID
-	Value       *string
-	SecretID    *uuid.UUID
+	Meta           EntityMeta
+	OrganizationID uuid.UUID
+	Name           string
+	Description    string
+	AgentID        *uuid.UUID
+	McpID          *uuid.UUID
+	HookID         *uuid.UUID
+	EnvironmentID  *uuid.UUID
+	Value          *string
+	SecretID       *uuid.UUID
 }
 
 type Environment struct {
@@ -352,13 +354,14 @@ type HookUpdate struct {
 }
 
 type EnvInput struct {
-	Name        string
-	Description string
-	AgentID     *uuid.UUID
-	McpID       *uuid.UUID
-	HookID      *uuid.UUID
-	Value       *string
-	SecretID    *uuid.UUID
+	Name          string
+	Description   string
+	AgentID       *uuid.UUID
+	McpID         *uuid.UUID
+	HookID        *uuid.UUID
+	EnvironmentID *uuid.UUID
+	Value         *string
+	SecretID      *uuid.UUID
 }
 
 type EnvUpdate struct {
@@ -441,10 +444,16 @@ type HookFilter struct {
 	AgentID *uuid.UUID
 }
 
+// EnvFilter narrows a list of envs. OrganizationID is what keeps a list inside
+// one tenant; it is a pointer because the Agents Orchestrator lists an
+// environment's envs over the mesh without naming an organization, and the
+// remaining fields narrow within whatever scope results.
 type EnvFilter struct {
-	AgentID *uuid.UUID
-	McpID   *uuid.UUID
-	HookID  *uuid.UUID
+	OrganizationID *uuid.UUID
+	AgentID        *uuid.UUID
+	McpID          *uuid.UUID
+	HookID         *uuid.UUID
+	EnvironmentID  *uuid.UUID
 }
 
 type InitScriptFilter struct {

--- a/migrations/0015_environment_runner_flavor.sql
+++ b/migrations/0015_environment_runner_flavor.sql
@@ -1,0 +1,14 @@
+-- Placement moves from a flavor id to a runner plus a flavor name: the runner
+-- declares its own catalog, and the name is resolved against it at workload
+-- start rather than being a foreign key to a platform record.
+ALTER TABLE environments
+    ADD COLUMN IF NOT EXISTS runner_id UUID,
+    ADD COLUMN IF NOT EXISTS flavor TEXT NOT NULL DEFAULT '';
+
+-- flavor_id is retained for callers still reading it and is no longer required.
+-- New environments name a runner instead; a null runner_id is an environment
+-- written before this change, which stays unschedulable until it is updated.
+ALTER TABLE environments
+    ALTER COLUMN flavor_id DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_environments_runner ON environments (runner_id);

--- a/migrations/0016_env_organization_scope.sql
+++ b/migrations/0016_env_organization_scope.sql
@@ -1,0 +1,66 @@
+-- An env names a value or a secret, and nothing on the row said which
+-- organization owned it. Reads stayed inside one tenant only by being narrowed
+-- to a parent id, which is why an unfiltered list had to be refused outright
+-- rather than authorized. The organization is already derivable from the parent
+-- chain, so it is recorded on the row and reads are scoped by it instead.
+--
+-- environment_id joins agent_id, mcp_id and hook_id as a target. An environment
+-- belongs to an organization rather than to an agent, which is the other reason
+-- the row now has to carry the organization itself.
+ALTER TABLE envs
+    ADD COLUMN organization_id UUID,
+    ADD COLUMN environment_id UUID;
+
+UPDATE envs
+SET organization_id = agents.organization_id
+FROM agents
+WHERE envs.agent_id = agents.id;
+
+UPDATE envs
+SET organization_id = agents.organization_id
+FROM mcps
+    JOIN agents ON agents.id = mcps.agent_id
+WHERE envs.mcp_id = mcps.id;
+
+UPDATE envs
+SET organization_id = agents.organization_id
+FROM hooks
+    JOIN agents ON agents.id = hooks.agent_id
+WHERE envs.hook_id = hooks.id;
+
+-- Every row must resolve: exactly one target is set, each target is a foreign
+-- key, and mcps and hooks both carry a non-null agent. A row that does not
+-- resolve is corruption no automatic choice can repair. Deleting it would drop
+-- a secret reference some workload still reads, and parking it in a placeholder
+-- organization would hand it to whoever holds that organization -- the opposite
+-- of what scoping these rows is for. Stop instead: migrations apply in one
+-- transaction, so the database is left exactly as it was.
+DO $$
+DECLARE
+    unresolved BIGINT;
+BEGIN
+    SELECT count(*) INTO unresolved FROM envs WHERE organization_id IS NULL;
+    IF unresolved > 0 THEN
+        RAISE EXCEPTION 'envs: % row(s) reach no organization through agent_id, mcp_id or hook_id', unresolved;
+    END IF;
+END
+$$;
+
+ALTER TABLE envs
+    ALTER COLUMN organization_id SET NOT NULL;
+
+-- The unnamed target check from 0003, which admits only an agent, an mcp or a
+-- hook.
+ALTER TABLE envs
+    DROP CONSTRAINT envs_check;
+
+ALTER TABLE envs
+    ADD CONSTRAINT envs_target_check CHECK (
+        (agent_id IS NOT NULL)::int + (mcp_id IS NOT NULL)::int + (hook_id IS NOT NULL)::int + (environment_id IS NOT NULL)::int = 1
+    ),
+    -- Composite, as sandboxes reference environments, so an env and the
+    -- environment it targets cannot drift into different organizations.
+    ADD CONSTRAINT envs_environment_fkey FOREIGN KEY (organization_id, environment_id) REFERENCES environments (organization_id, id);
+
+CREATE INDEX envs_organization_id_idx ON envs (organization_id);
+CREATE INDEX envs_environment_id_idx ON envs (environment_id);

--- a/migrations/0017_image_pull_secret_attachment_organization_scope.sql
+++ b/migrations/0017_image_pull_secret_attachment_organization_scope.sql
@@ -1,0 +1,71 @@
+-- An image pull secret attachment names a registry credential, and nothing on
+-- the row said which organization owned it. Reads stayed inside one tenant only
+-- by being narrowed to a parent id, which is why an unfiltered list had to be
+-- refused outright rather than authorized. The organization is already derivable
+-- from the parent chain, so it is recorded on the row and reads are scoped by it
+-- instead.
+--
+-- environment_id joins agent_id, mcp_id and hook_id as a target. An environment
+-- belongs to an organization rather than to an agent, which is the other reason
+-- the row now has to carry the organization itself.
+ALTER TABLE image_pull_secret_attachments
+    ADD COLUMN organization_id UUID,
+    ADD COLUMN environment_id UUID;
+
+UPDATE image_pull_secret_attachments
+SET organization_id = agents.organization_id
+FROM agents
+WHERE image_pull_secret_attachments.agent_id = agents.id;
+
+UPDATE image_pull_secret_attachments
+SET organization_id = agents.organization_id
+FROM mcps
+    JOIN agents ON agents.id = mcps.agent_id
+WHERE image_pull_secret_attachments.mcp_id = mcps.id;
+
+UPDATE image_pull_secret_attachments
+SET organization_id = agents.organization_id
+FROM hooks
+    JOIN agents ON agents.id = hooks.agent_id
+WHERE image_pull_secret_attachments.hook_id = hooks.id;
+
+-- Every row must resolve: exactly one target is set, each target is a foreign
+-- key, and mcps and hooks both carry a non-null agent. A row that does not
+-- resolve is corruption no automatic choice can repair. Deleting it would drop
+-- the credential a workload still pulls its image with, and parking it in a
+-- placeholder organization would hand it to whoever holds that organization --
+-- the opposite of what scoping these rows is for. Stop instead: migrations
+-- apply in one transaction, so the database is left exactly as it was.
+DO $$
+DECLARE
+    unresolved BIGINT;
+BEGIN
+    SELECT count(*) INTO unresolved FROM image_pull_secret_attachments WHERE organization_id IS NULL;
+    IF unresolved > 0 THEN
+        RAISE EXCEPTION 'image_pull_secret_attachments: % row(s) reach no organization through agent_id, mcp_id or hook_id', unresolved;
+    END IF;
+END
+$$;
+
+ALTER TABLE image_pull_secret_attachments
+    ALTER COLUMN organization_id SET NOT NULL;
+
+-- The unnamed target check from 0009, which admits only an agent, an mcp or a
+-- hook.
+ALTER TABLE image_pull_secret_attachments
+    DROP CONSTRAINT image_pull_secret_attachments_check;
+
+ALTER TABLE image_pull_secret_attachments
+    ADD CONSTRAINT image_pull_secret_attachments_target_check CHECK (
+        (agent_id IS NOT NULL)::int + (mcp_id IS NOT NULL)::int + (hook_id IS NOT NULL)::int + (environment_id IS NOT NULL)::int = 1
+    ),
+    -- Composite, as sandboxes reference environments, so an attachment and the
+    -- environment it targets cannot drift into different organizations.
+    ADD CONSTRAINT image_pull_secret_attachments_environment_fkey FOREIGN KEY (organization_id, environment_id) REFERENCES environments (organization_id, id);
+
+-- The same one-attachment-per-target rule 0009 gave the other three targets.
+CREATE UNIQUE INDEX image_pull_secret_attachments_unique_environment
+    ON image_pull_secret_attachments (image_pull_secret_id, environment_id) WHERE environment_id IS NOT NULL;
+
+CREATE INDEX image_pull_secret_attachments_organization_id_idx ON image_pull_secret_attachments (organization_id);
+CREATE INDEX image_pull_secret_attachments_environment_id_idx ON image_pull_secret_attachments (environment_id);

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -297,12 +297,18 @@ func TestAgentsServiceE2E(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, secretID, updatedEnvResp.Env.GetSecretId())
 
-		envsByAgent := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{AgentId: agentID})
+		envsByAgent := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{OrganizationId: testOrganizationID, AgentId: agentID})
 		require.True(t, hasID(envsByAgent, envID))
-		envsByMcp := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{McpId: mcpID})
+		envsByMcp := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{OrganizationId: testOrganizationID, McpId: mcpID})
 		require.True(t, hasID(envsByMcp, envMcpID))
-		envsByHook := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{HookId: hookID})
+		envsByHook := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{OrganizationId: testOrganizationID, HookId: hookID})
 		require.True(t, hasID(envsByHook, envHookID))
+
+		// The organization alone is enough; the target ids only narrow it.
+		envsByOrganization := listEnvs(ctx, t, client, &agentsv1.ListEnvsRequest{OrganizationId: testOrganizationID})
+		require.True(t, hasID(envsByOrganization, envID))
+		require.True(t, hasID(envsByOrganization, envMcpID))
+		require.True(t, hasID(envsByOrganization, envHookID))
 
 		_, err = client.DeleteEnv(ctx, &agentsv1.DeleteEnvRequest{Id: envHookID})
 		require.NoError(t, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -576,10 +576,16 @@ func TestAgentsServiceE2E(t *testing.T) {
 		require.Equal(t, imagePullSecretID, getHookAttachmentResp.ImagePullSecretAttachment.ImagePullSecretId)
 		require.Equal(t, hookID, getHookAttachmentResp.ImagePullSecretAttachment.GetHookId())
 
-		attachments := listImagePullSecretAttachments(ctx, t, client, &agentsv1.ListImagePullSecretAttachmentsRequest{ImagePullSecretId: imagePullSecretID})
+		attachments := listImagePullSecretAttachments(ctx, t, client, &agentsv1.ListImagePullSecretAttachmentsRequest{OrganizationId: testOrganizationID, ImagePullSecretId: imagePullSecretID})
 		require.True(t, hasID(attachments, attachmentID))
 		require.True(t, hasID(attachments, mcpAttachmentID))
 		require.True(t, hasID(attachments, hookAttachmentID))
+
+		// The organization alone is enough; the target ids only narrow it.
+		attachmentsByOrganization := listImagePullSecretAttachments(ctx, t, client, &agentsv1.ListImagePullSecretAttachmentsRequest{OrganizationId: testOrganizationID})
+		require.True(t, hasID(attachmentsByOrganization, attachmentID))
+		require.True(t, hasID(attachmentsByOrganization, mcpAttachmentID))
+		require.True(t, hasID(attachmentsByOrganization, hookAttachmentID))
 
 		_, err = client.DeleteImagePullSecretAttachment(ctx, &agentsv1.DeleteImagePullSecretAttachmentRequest{Id: hookAttachmentID})
 		require.NoError(t, err)


### PR DESCRIPTION
Part of the sandboxes feature. **This is what makes environment creation work** — without it the server still demands the deprecated `flavor_id` and ignores `runner_id`/`flavor`, so the console fails with `flavor_id: value is empty`.

**Environments place workloads by runner and flavor name.** `flavor_id` pointed at a platform-owned flavor row; placement is now environment → runner directly, with the flavor named within that runner's reported catalog. The flavor name is deliberately not validated on write — it resolves at workload start, so an environment and the runner configuration naming its flavor can be applied in either order.

**Organization scoping.** Envs and image-pull-secret attachments now record the organization they belong to, and the list RPCs authorize against the organization named in the request. Several list RPCs previously ran no authorization at all, against what agents-service.md specifies.

**Sandbox identity.** A sandbox workload can read its own record — platform services it dials resolve it through that record — and the Orchestrator can list sandboxes internally over the mesh without an identity, since it holds no OpenFGA tuples and a check could only ever refuse it.

Depends on agynio/runners#72 for the catalog these environments reference.

Note: agynio/agents#65 (cluster admin own-listing) branches from main and will need rebasing onto this.