### PR TITLE
feat(sandbox): make the workload a member of its organization

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -210,6 +210,7 @@ func (s *Server) addSandboxAuthorization(ctx context.Context, sandboxID uuid.UUI
 	return s.writeAuthorization(ctx, []*authorizationv1.TupleKey{
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
+		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
 	}, nil)
 }
 
@@ -217,6 +218,7 @@ func (s *Server) removeSandboxAuthorization(ctx context.Context, sandboxID uuid.
 	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
+		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
 	})
 }
 
@@ -289,6 +291,22 @@ func sandboxOrganizationTuple(sandboxID uuid.UUID, organizationID uuid.UUID) *au
 		User:     organizationPrefix + organizationID.String(),
 		Relation: "org",
 		Object:   sandboxPrefix + sandboxID.String(),
+	}
+}
+
+// sandboxIdentityOrganizationMembershipTuple makes the sandbox workload a
+// member of its organization, the same way an agent workload is one.
+//
+// The workload authenticates as its own sandbox id, and without this it holds
+// no relation at all: every service it dials would refuse it, because the
+// checks they run — member on the organization — have nothing to resolve. The
+// identity type is not what earns the access; the tuple is, exactly as for
+// every other identity.
+func sandboxIdentityOrganizationMembershipTuple(sandboxID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + sandboxID.String(),
+		Relation: "member",
+		Object:   organizationPrefix + organizationID.String(),
 	}
 }
 

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -105,8 +105,38 @@ func TestAddSandboxAuthorizationWritesOrgAndOwner(t *testing.T) {
 	assertTuples(t, request.GetWrites(), []*authorizationv1.TupleKey{
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
+		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
 	})
 	assertTuples(t, request.GetDeletes(), nil)
+}
+
+// The workload's access comes from this tuple, not from its identity type, so
+// assert the literal user/relation/object rather than re-deriving it.
+func TestSandboxIdentityBecomesOrganizationMember(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	sandboxID := uuid.New()
+	organizationID := uuid.New()
+
+	if err := server.addSandboxAuthorization(context.Background(), sandboxID, organizationID, uuid.New()); err != nil {
+		t.Fatalf("add sandbox authorization: %v", err)
+	}
+
+	var found *authorizationv1.TupleKey
+	for _, tuple := range singleWriteRequest(t, authz).GetWrites() {
+		if tuple.GetRelation() == "member" {
+			found = tuple
+		}
+	}
+	if found == nil {
+		t.Fatal("expected the sandbox workload to be written as an organization member")
+	}
+	if found.GetUser() != "identity:"+sandboxID.String() {
+		t.Fatalf("expected the sandbox's own identity, got %q", found.GetUser())
+	}
+	if found.GetObject() != "organization:"+organizationID.String() {
+		t.Fatalf("expected membership of the sandbox organization, got %q", found.GetObject())
+	}
 }
 
 func TestRemoveSandboxAuthorizationDeletesOrgAndOwner(t *testing.T) {
@@ -125,6 +155,7 @@ func TestRemoveSandboxAuthorizationDeletesOrgAndOwner(t *testing.T) {
 	assertTuples(t, request.GetDeletes(), []*authorizationv1.TupleKey{
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
+		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
 	})
 }
 


### PR DESCRIPTION
A sandbox workload authenticates as its own sandbox id and holds **no OpenFGA relation at all**, so every service it dials refuses it — the checks they run (`member on organization`) have nothing to resolve.

The Gateway papered over that with a procedure allowlist keyed on identity type. `authz.md:40` rules that out directly: all identities are a single `identity` type in OpenFGA, and "services do not need to know the identity type when constructing tuples or performing checks".

An agent workload already solves this with a plain tuple — `agentIdentityOrganizationMembershipTuple` writes `identity:<agent_id> member organization:<org_id>` at creation, so an agent passes the same checks a user does, with no special path anywhere. A sandbox now gets the same tuple, written and removed alongside the rest of its authorization.

This is deliberately **flat** membership, matching agents rather than improving on them. Narrowing a workload to no more than its owner holds is worth doing — for agents too — and is not this change.

Pairs with agynio/gateway#196, which removes the allowlist and the /me and app-proxy blocks. Neither is much use without the other.

The added test asserts the literal user/relation/object rather than re-deriving it from the helper, since the whole point is that access comes from the tuple's shape.