### PR TITLE
feat(agents): record and serve an agent's environment

### DIFF
--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// The migrations under test. Each derives an organization for every row already
-// in its table from the target that row carries, so reads can be scoped by it.
+// The migrations under test. The first two derive an organization for every row
+// already in their table from the target that row carries, so reads can be
+// scoped by it. The third gives agents the environment reference that supersedes
+// the image and compute they carried inline.
 const (
 	envOrganizationScopeMigration                       = "0016_env_organization_scope.sql"
 	imagePullSecretAttachmentOrganizationScopeMigration = "0017_image_pull_secret_attachment_organization_scope.sql"
+	agentEnvironmentMigration                           = "0018_agent_environment.sql"
 )
 
 const (
@@ -252,5 +255,61 @@ func TestImagePullSecretAttachmentOrganizationBackfillStopsOnAnAttachmentWithNoO
 	}
 	if columns != 0 {
 		t.Fatal("expected the migration to roll back and leave image_pull_secret_attachments untouched")
+	}
+}
+
+// The reference is composite, the way sandboxes reference environments, so the
+// database itself refuses an agent pointing at another organization's
+// environment. The server checks it first and answers InvalidArgument; this is
+// the floor underneath that check.
+func TestAgentEnvironmentForeignKeyRefusesAnotherOrganizationsEnvironment(t *testing.T) {
+	ctx := context.Background()
+	pool := migrationTestPool(ctx, t)
+	applyMigrationsBefore(ctx, t, pool, agentEnvironmentMigration)
+	seedTargetsAcrossOrganizations(ctx, t, pool)
+
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	execAll(ctx, t, pool, []string{
+		`INSERT INTO environments (id, organization_id, name, flavor_id, image) VALUES
+			('eeeeeeee-0000-0000-0000-000000000001', '` + organizationOne + `', 'one', uuid_generate_v4(), 'env:1')`,
+	})
+
+	// The agent is organizationTwo's and the environment organizationOne's.
+	if _, err := pool.Exec(ctx,
+		`UPDATE agents SET environment_id = 'eeeeeeee-0000-0000-0000-000000000001' WHERE id = 'aaaaaaaa-0000-0000-0000-000000000002'`,
+	); err == nil {
+		t.Fatal("expected an agent to be refused an environment from another organization")
+	}
+
+	// The same environment is accepted by the agent that does share its
+	// organization, so what was refused is the mismatch and not the reference.
+	if _, err := pool.Exec(ctx,
+		`UPDATE agents SET environment_id = 'eeeeeeee-0000-0000-0000-000000000001' WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'`,
+	); err != nil {
+		t.Fatalf("expected an environment from the agent's own organization to be accepted: %v", err)
+	}
+}
+
+// Every agent written before environments existed keeps running from the image
+// and compute it carries inline, so the column has to admit no reference at all.
+func TestAgentEnvironmentIsNullableForAgentsThatPredateEnvironments(t *testing.T) {
+	ctx := context.Background()
+	pool := migrationTestPool(ctx, t)
+	applyMigrationsBefore(ctx, t, pool, agentEnvironmentMigration)
+	seedTargetsAcrossOrganizations(ctx, t, pool)
+
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	var withoutEnvironment int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM agents WHERE environment_id IS NULL`).Scan(&withoutEnvironment); err != nil {
+		t.Fatalf("read agents: %v", err)
+	}
+	if withoutEnvironment != 2 {
+		t.Fatalf("expected both seeded agents to carry no environment, got %d", withoutEnvironment)
 	}
 }

--- a/internal/server/agent_environment_test.go
+++ b/internal/server/agent_environment_test.go
@@ -1,0 +1,289 @@
+package server
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agents/internal/db"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const testInitImage = "ghcr.io/agynio/agent-init-codex:latest"
+
+// agentEnvironmentServer builds a server over the database named by
+// AGENTS_TEST_DATABASE_URL and empties it first. The variable must name a
+// scratch database, never one holding anything worth keeping. It is unset in
+// ordinary runs and these tests are then skipped, so the package needs no
+// database to be tested.
+//
+// The reference is recorded and served across the store, the composite foreign
+// key and the proto converter at once, so it is exercised through the RPCs
+// rather than through any one of them.
+func agentEnvironmentServer(ctx context.Context, t *testing.T) *Server {
+	t.Helper()
+	url := os.Getenv("AGENTS_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("AGENTS_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if err := db.ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+	return New(store.New(pool), noopAuthorizationWriter{}, noopIdentityWriter{}, noopNotificationsClient{})
+}
+
+func createTestEnvironment(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, name string) string {
+	t.Helper()
+	response, err := server.CreateEnvironment(ctx, &agentsv1.CreateEnvironmentRequest{
+		OrganizationId: organizationID.String(),
+		RunnerId:       uuid.NewString(),
+		Name:           name,
+		Image:          "ghcr.io/agynio/environment:latest",
+		Flavor:         "small",
+	})
+	if err != nil {
+		t.Fatalf("create environment: %v", err)
+	}
+	return response.GetEnvironment().GetMeta().GetId()
+}
+
+func createAgentRequest(organizationID uuid.UUID, name string) *agentsv1.CreateAgentRequest {
+	return &agentsv1.CreateAgentRequest{
+		OrganizationId: organizationID.String(),
+		Name:           name,
+		Model:          uuid.NewString(),
+		InitImage:      testInitImage,
+		Availability:   agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL,
+	}
+}
+
+// An agent's environment is what supplies its image and compute, replacing the
+// copy each agent used to carry inline.
+func TestCreateAgentPersistsTheEnvironmentReference(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+	environmentID := createTestEnvironment(ctx, t, server, organizationID, "default")
+
+	request := createAgentRequest(organizationID, "alpha")
+	request.EnvironmentId = environmentID
+	created, err := server.CreateAgent(ctx, request)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	if created.GetAgent().GetEnvironmentId() != environmentID {
+		t.Fatalf("expected environment %s on the created agent, got %q", environmentID, created.GetAgent().GetEnvironmentId())
+	}
+
+	agentID := created.GetAgent().GetMeta().GetId()
+	fetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if fetched.GetAgent().GetEnvironmentId() != environmentID {
+		t.Fatalf("expected environment %s on the fetched agent, got %q", environmentID, fetched.GetAgent().GetEnvironmentId())
+	}
+
+	listed, err := server.ListAgents(ctx, &agentsv1.ListAgentsRequest{OrganizationId: organizationID.String()})
+	if err != nil {
+		t.Fatalf("list agents: %v", err)
+	}
+	if len(listed.GetAgents()) != 1 {
+		t.Fatalf("expected one agent, got %d", len(listed.GetAgents()))
+	}
+	if listed.GetAgents()[0].GetEnvironmentId() != environmentID {
+		t.Fatalf("expected environment %s on the listed agent, got %q", environmentID, listed.GetAgents()[0].GetEnvironmentId())
+	}
+}
+
+// The reference is optional: agents created before environments existed have
+// none, and one can still be created without naming an environment.
+func TestCreateAgentWithoutAnEnvironmentLeavesItEmpty(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	if created.GetAgent().GetEnvironmentId() != "" {
+		t.Fatalf("expected no environment on the created agent, got %q", created.GetAgent().GetEnvironmentId())
+	}
+
+	fetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: created.GetAgent().GetMeta().GetId()})
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if fetched.GetAgent().GetEnvironmentId() != "" {
+		t.Fatalf("expected no environment on the fetched agent, got %q", fetched.GetAgent().GetEnvironmentId())
+	}
+}
+
+// An environment belongs to one organization, and an agent naming another
+// organization's would reach across tenants. The composite foreign key refuses
+// it, but the caller is told which field was wrong instead of being handed a
+// constraint violation.
+func TestAgentRefusesAnEnvironmentFromAnotherOrganization(t *testing.T) {
+	tests := []struct {
+		name string
+		// refuse names an environment belonging to otherOrganizationID on an
+		// agent in organizationID, and reports the error the RPC returned.
+		refuse func(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, environmentID string) error
+	}{
+		{
+			name: "create",
+			refuse: func(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, environmentID string) error {
+				request := createAgentRequest(organizationID, "alpha")
+				request.EnvironmentId = environmentID
+				_, err := server.CreateAgent(ctx, request)
+				return err
+			},
+		},
+		{
+			name: "update",
+			refuse: func(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, environmentID string) error {
+				t.Helper()
+				created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+				if err != nil {
+					t.Fatalf("create agent: %v", err)
+				}
+				_, err = server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
+					Id:            created.GetAgent().GetMeta().GetId(),
+					EnvironmentId: ptr(environmentID),
+				})
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := identityContext(uuid.New())
+			server := agentEnvironmentServer(ctx, t)
+			organizationID := uuid.New()
+			otherOrganizationID := uuid.New()
+			environmentID := createTestEnvironment(ctx, t, server, otherOrganizationID, "default")
+
+			err := test.refuse(ctx, t, server, organizationID, environmentID)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("expected invalid argument, got %v", err)
+			}
+			if got := status.Convert(err).Message(); got != "environment_id: environment belongs to another organization" {
+				t.Fatalf("expected the environment_id field to be named, got %q", got)
+			}
+		})
+	}
+}
+
+// An agent may move to an environment it did not name at creation, and may give
+// one up again — an agent with none is the state every agent was in before
+// environments existed.
+func TestUpdateAgentSetsAndClearsTheEnvironmentReference(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+	environmentID := createTestEnvironment(ctx, t, server, organizationID, "default")
+
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agentID := created.GetAgent().GetMeta().GetId()
+
+	updated, err := server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
+		Id:            agentID,
+		EnvironmentId: ptr(environmentID),
+	})
+	if err != nil {
+		t.Fatalf("update agent: %v", err)
+	}
+	if updated.GetAgent().GetEnvironmentId() != environmentID {
+		t.Fatalf("expected environment %s after the update, got %q", environmentID, updated.GetAgent().GetEnvironmentId())
+	}
+
+	fetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if fetched.GetAgent().GetEnvironmentId() != environmentID {
+		t.Fatalf("expected environment %s to be stored, got %q", environmentID, fetched.GetAgent().GetEnvironmentId())
+	}
+
+	cleared, err := server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
+		Id:            agentID,
+		EnvironmentId: ptr(""),
+	})
+	if err != nil {
+		t.Fatalf("clear environment: %v", err)
+	}
+	if cleared.GetAgent().GetEnvironmentId() != "" {
+		t.Fatalf("expected no environment after clearing, got %q", cleared.GetAgent().GetEnvironmentId())
+	}
+
+	refetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if refetched.GetAgent().GetEnvironmentId() != "" {
+		t.Fatalf("expected the cleared environment to be stored, got %q", refetched.GetAgent().GetEnvironmentId())
+	}
+}
+
+// An environment_id naming no environment at all is the caller's mistake, not
+// an internal failure.
+func TestAgentRefusesAnUnknownEnvironment(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+
+	request := createAgentRequest(organizationID, "alpha")
+	request.EnvironmentId = uuid.NewString()
+	if _, err := server.CreateAgent(ctx, request); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
+func TestCreateAgentRejectsAMalformedEnvironment(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+
+	request := createAgentRequest(uuid.New(), "alpha")
+	request.EnvironmentId = "not-a-uuid"
+	if _, err := server.CreateAgent(ctx, request); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
+// environment_id alone is enough of an update; it used to be possible to send
+// only fields the request rejected as empty.
+func TestUpdateAgentAcceptsTheEnvironmentAsTheOnlyField(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+	environmentID := createTestEnvironment(ctx, t, server, organizationID, "default")
+
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	if _, err := server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
+		Id:            created.GetAgent().GetMeta().GetId(),
+		EnvironmentId: ptr(environmentID),
+	}); err != nil {
+		t.Fatalf("update agent: %v", err)
+	}
+}

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -44,6 +44,11 @@ func toProtoAgent(agent store.Agent) *agentsv1.Agent {
 	if agent.IdleTimeout != nil {
 		protoAgent.IdleTimeout = agent.IdleTimeout
 	}
+	// Empty on agents created before environments existed, which run from the
+	// deprecated inline image and resources above.
+	if agent.EnvironmentID != nil {
+		protoAgent.EnvironmentId = agent.EnvironmentID.String()
+	}
 	return protoAgent
 }
 

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -375,6 +375,40 @@ func TestToProtoAgentInstanceBuildsHandle(t *testing.T) {
 	}
 }
 
+func TestToProtoAgentCarriesTheEnvironmentReference(t *testing.T) {
+	environmentID := uuid.New()
+	agent := store.Agent{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Name:           "alpha",
+		Availability:   store.AgentAvailabilityInternal,
+		EnvironmentID:  &environmentID,
+	}
+
+	protoAgent := toProtoAgent(agent)
+
+	if protoAgent.GetEnvironmentId() != environmentID.String() {
+		t.Fatalf("expected environment %s, got %q", environmentID, protoAgent.GetEnvironmentId())
+	}
+}
+
+// An agent created before environments existed has none, and the field stays
+// empty rather than reporting the zero UUID as a reference.
+func TestToProtoAgentLeavesTheEnvironmentEmptyWhenUnset(t *testing.T) {
+	agent := store.Agent{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Name:           "alpha",
+		Availability:   store.AgentAvailabilityInternal,
+	}
+
+	protoAgent := toProtoAgent(agent)
+
+	if protoAgent.GetEnvironmentId() != "" {
+		t.Fatalf("expected no environment, got %q", protoAgent.GetEnvironmentId())
+	}
+}
+
 func TestToProtoImagePullSecretAttachmentCarriesTheEnvironmentTarget(t *testing.T) {
 	environmentID := uuid.New()
 	attachment := store.ImagePullSecretAttachment{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,29 @@ func (s *Server) removeAgentNickname(ctx context.Context, agentID uuid.UUID, org
 	return err
 }
 
+// environmentInOrganization resolves an environment_id and refuses one naming an
+// environment in another organization. The composite foreign key on agents
+// refuses that too, but the violation would reach the caller as an opaque
+// internal error rather than naming the field that was wrong.
+func (s *Server) environmentInOrganization(ctx context.Context, value string, organizationID uuid.UUID) (uuid.UUID, error) {
+	environmentID, err := parseUUID(value)
+	if err != nil {
+		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+	}
+	environment, err := s.store.GetEnvironment(ctx, environmentID)
+	if err != nil {
+		var notFound *store.NotFoundError
+		if errors.As(err, &notFound) {
+			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		return uuid.UUID{}, toStatusError(err)
+	}
+	if environment.OrganizationID != organizationID {
+		return uuid.UUID{}, status.Error(codes.InvalidArgument, "environment_id: environment belongs to another organization")
+	}
+	return environmentID, nil
+}
+
 func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentRequest) (*agentsv1.CreateAgentResponse, error) {
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
@@ -141,6 +164,16 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	if err := validateDurationString(idleTimeout); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "idle_timeout: %v", err)
 	}
+	// Optional: an agent may name no environment and run from the deprecated
+	// inline image and resources instead.
+	var environmentID *uuid.UUID
+	if req.GetEnvironmentId() != "" {
+		resolved, err := s.environmentInOrganization(ctx, req.GetEnvironmentId(), organizationID)
+		if err != nil {
+			return nil, err
+		}
+		environmentID = &resolved
+	}
 	nickname := req.GetNickname()
 	resources := toStoreComputeResources(req.GetResources())
 	agent, err := s.store.CreateAgent(ctx, organizationID, store.AgentInput{
@@ -156,6 +189,7 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 		Capabilities:  append([]string(nil), req.GetCapabilities()...),
 		Availability:  availability,
 		Resources:     resources,
+		EnvironmentID: environmentID,
 	})
 	if err != nil {
 		return nil, toStatusError(err)
@@ -256,7 +290,8 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	// list replaces existing capabilities.
 	capabilitiesProvided := req.Capabilities != nil
 	availabilityProvided := req.Availability != nil
-	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided {
+	environmentProvided := req.EnvironmentId != nil
+	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided && !environmentProvided {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	if req.InitImage != nil && req.GetInitImage() == "" {
@@ -267,7 +302,9 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	var previousAgent store.Agent
 	var nicknameValue string
 	var nicknameUpdateNeeded bool
-	if nicknameProvided || availabilityProvided {
+	// An environment is checked against the agent's organization, which only the
+	// stored agent names.
+	if nicknameProvided || availabilityProvided || environmentProvided {
 		previousAgent, err = s.store.GetAgent(ctx, id)
 		if err != nil {
 			return nil, toStatusError(err)
@@ -335,6 +372,19 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	if req.Resources != nil {
 		resources := toStoreComputeResources(req.GetResources())
 		update.Resources = &resources
+	}
+	if environmentProvided {
+		// An empty environment_id clears the reference rather than naming an
+		// environment, leaving the agent as one created before they existed.
+		if req.GetEnvironmentId() == "" {
+			update.ClearEnvironmentID = true
+		} else {
+			environmentID, err := s.environmentInOrganization(ctx, req.GetEnvironmentId(), previousAgent.OrganizationID)
+			if err != nil {
+				return nil, err
+			}
+			update.EnvironmentID = &environmentID
+		}
 	}
 
 	agent, err := s.store.UpdateAgent(ctx, id, update)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, created_at, updated_at`
+	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, created_at, updated_at`
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, organization_id, image_pull_secret_id, agent_id, mcp_id, hook_id, environment_id, created_at, updated_at`
@@ -80,6 +80,7 @@ func scanAgent(row pgx.Row) (Agent, error) {
 	var agent Agent
 	var idleTimeout pgtype.Text
 	var capabilities []byte
+	var environmentID pgtype.UUID
 	if err := row.Scan(
 		&agent.Meta.ID,
 		&agent.OrganizationID,
@@ -98,12 +99,14 @@ func scanAgent(row pgx.Row) (Agent, error) {
 		&agent.Resources.RequestsMemory,
 		&agent.Resources.LimitsCPU,
 		&agent.Resources.LimitsMemory,
+		&environmentID,
 		&agent.Meta.CreatedAt,
 		&agent.Meta.UpdatedAt,
 	); err != nil {
 		return Agent{}, err
 	}
 	agent.IdleTimeout = stringPtrFromPg(idleTimeout)
+	agent.EnvironmentID = uuidPtrFromPg(environmentID)
 	decodedCapabilities, err := decodeCapabilities(capabilities)
 	if err != nil {
 		return Agent{}, err
@@ -373,8 +376,8 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		return Agent{}, err
 	}
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 		 RETURNING %s`, agentColumns),
 		organizationID,
 		input.Name,
@@ -392,6 +395,7 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		input.Resources.RequestsMemory,
 		input.Resources.LimitsCPU,
 		input.Resources.LimitsMemory,
+		input.EnvironmentID,
 	)
 	agent, err := scanAgent(row)
 	if err != nil {
@@ -416,6 +420,9 @@ func (s *Store) GetAgent(ctx context.Context, id uuid.UUID) (Agent, error) {
 }
 
 func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdate) (Agent, error) {
+	if update.EnvironmentID != nil && update.ClearEnvironmentID {
+		return Agent{}, fmt.Errorf("agent update cannot set and clear environment_id")
+	}
 	builder := updateBuilder{}
 	if update.Name != nil {
 		builder.add("name", *update.Name)
@@ -459,6 +466,12 @@ func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdat
 		builder.add("resources_requests_memory", update.Resources.RequestsMemory)
 		builder.add("resources_limits_cpu", update.Resources.LimitsCPU)
 		builder.add("resources_limits_memory", update.Resources.LimitsMemory)
+	}
+	if update.EnvironmentID != nil {
+		builder.add("environment_id", *update.EnvironmentID)
+	}
+	if update.ClearEnvironmentID {
+		builder.addNull("environment_id")
 	}
 
 	if builder.empty() {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -34,6 +34,10 @@ type Agent struct {
 	Capabilities   []string
 	Availability   AgentAvailability
 	Resources      ComputeResources
+	// The environment supplying this agent's image and compute. Null on agents
+	// written before environments existed, which still carry Image and
+	// Resources of their own.
+	EnvironmentID *uuid.UUID
 }
 
 type AgentAvailability string
@@ -262,6 +266,7 @@ type AgentInput struct {
 	Capabilities  []string
 	Availability  AgentAvailability
 	Resources     ComputeResources
+	EnvironmentID *uuid.UUID
 }
 
 type AgentUpdate struct {
@@ -277,6 +282,10 @@ type AgentUpdate struct {
 	Capabilities  *[]string
 	Availability  *AgentAvailability
 	Resources     *ComputeResources
+	// EnvironmentID sets the reference and ClearEnvironmentID removes it; an
+	// agent may have none, so the two cases are distinct.
+	EnvironmentID      *uuid.UUID
+	ClearEnvironmentID bool
 }
 
 type VolumeInput struct {

--- a/migrations/0018_agent_environment.sql
+++ b/migrations/0018_agent_environment.sql
@@ -1,0 +1,17 @@
+-- An agent carried its own image and compute resources inline, duplicating what
+-- an environment already is: one runtime definition an agent and a sandbox can
+-- both point at. The reference is recorded here so an agent can name one.
+--
+-- Nullable, and null on every agent written before environments existed. Those
+-- agents keep the inline image and resources they still carry, which remain in
+-- place and are still read.
+ALTER TABLE agents
+    ADD COLUMN environment_id UUID;
+
+-- Composite, the way sandboxes reference environments, so an agent cannot
+-- reference an environment belonging to another organization. A null
+-- environment_id satisfies it, which is what leaves the column optional.
+ALTER TABLE agents
+    ADD CONSTRAINT agents_environment_fkey FOREIGN KEY (organization_id, environment_id) REFERENCES environments (organization_id, id);
+
+CREATE INDEX agents_environment_id_idx ON agents (environment_id);


### PR DESCRIPTION
`Sandbox` has carried `environment_id` since sandboxes shipped; `Agent` never did, so agents duplicate an image and compute inline — the duplication environments exist to remove. `agents-service.md:21` already describes an agent as holding an "environment reference".

Now that agynio/api#166 has published the field, this persists and serves it:

- **`0018_agent_environment.sql`** — nullable `environment_id` with a **composite** FK `(organization_id, environment_id) REFERENCES environments (organization_id, id)`, matching how 0017 scopes image-pull-secret attachments. An agent cannot reference another organization's environment even if the service layer were bypassed.
- **Store and server** — create, update (set and clear), get and list.
- **Validation** — a cross-organization environment is refused with `InvalidArgument` rather than surfacing a constraint violation. Optional throughout: agents created before environments existed have none, and keep the inline image and resources they still carry.

Out of scope by design: nothing changes about how workloads are assembled, and the deprecated inline `image`/`resources` are still read. Resolving an agent's runtime *from* its environment is the next change.

## Verified against a running cluster, not just unit tests

Migration applied to the live database (column and `agents_environment_fkey` both present), then through the Gateway:

- same-organization environment → accepted, persisted, returned
- cross-organization environment → `invalid_argument: environment_id: environment belongs to another organization`

Worth noting: the first cross-org attempt was **accepted**, because the Gateway's compiled binary predated its regenerated bindings and silently dropped the unknown field. Unit tests would not have caught that. It refuses correctly once both processes run current code.

Free consequence: `agents-service.md:22` says "Delete is rejected while any agent or sandbox references the environment" — that now holds for agents too, since the new FK makes `DeleteEnvironment`'s existing `23503 → FailedPrecondition` mapping fire.