### PR TITLE
fix: authorize reading a single agent instance

### DIFF
--- a/internal/server/instance_read_authorization_test.go
+++ b/internal/server/instance_read_authorization_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+)
+
+// GetInstance authorized nothing: any caller who knew an id read the instance,
+// including its organization and the agent behind it. It now decides on the
+// same terms ListInstances does, and these cover that decision. The RPC itself
+// loads from a concrete store these tests do not stand up, so what is exercised
+// is the check it delegates to, which takes the loaded instance as a value.
+func instanceFor(organizationID uuid.UUID) store.AgentInstance {
+	return store.AgentInstance{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		AgentID:        uuid.New(),
+		OrganizationID: organizationID,
+	}
+}
+
+func TestInstanceReadRefusesAnotherOrganization(t *testing.T) {
+	callerOrganizationID := uuid.New()
+	instance := instanceFor(uuid.New())
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + callerOrganizationID.String(): true,
+	}}
+	server := &Server{authz: authz}
+
+	err := server.requireInstanceReadAccess(identityContext(identityID), instance)
+	if err == nil {
+		t.Fatal("expected a caller from another organization to be refused")
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, instance.OrganizationID, "member"),
+	})
+}
+
+func TestInstanceReadServesAMemberOfTheOrganization(t *testing.T) {
+	instance := instanceFor(uuid.New())
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.requireInstanceReadAccess(identityContext(identityID), instance); err != nil {
+		t.Fatalf("expected a member to be served, got %v", err)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		organizationRelationTuple(identityID, instance.OrganizationID, "member"),
+	})
+}
+
+// Threads and the Agents Orchestrator resolve instances over the mesh rather
+// than the Gateway and carry no identity by design: they hold no tuples, so a
+// check could only refuse them. Breaking this stops agents from sending.
+func TestInstanceReadServesTheInternalCallerWithoutAnIdentity(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.requireInstanceReadAccess(t.Context(), instanceFor(uuid.New())); err != nil {
+		t.Fatalf("expected the internal caller to be served, got %v", err)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization checks, got %d", len(authz.checks))
+	}
+}
+
+// An instance is not a member of its organization, so membership alone would
+// deny it its own record.
+func TestInstanceReadServesTheInstanceItself(t *testing.T) {
+	instance := instanceFor(uuid.New())
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.requireInstanceReadAccess(identityContext(instance.Meta.ID), instance); err != nil {
+		t.Fatalf("expected the instance to read itself, got %v", err)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization checks, got %d", len(authz.checks))
+	}
+}
+
+func TestInstanceReadRejectsAMalformedIdentity(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	err := server.requireInstanceReadAccess(malformedIdentityContext(), instanceFor(uuid.New()))
+	if err == nil || !strings.Contains(err.Error(), "identity_id") {
+		t.Fatalf("expected a malformed identity to be rejected, got %v", err)
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -149,7 +149,26 @@ func (s *Server) GetInstance(ctx context.Context, req *agentsv1.GetInstanceReque
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireInstanceReadAccess(ctx, instance); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetInstanceResponse{Instance: toProtoAgentInstance(instance)}, nil
+}
+
+// requireInstanceReadAccess authorizes reading one instance on the same terms
+// ListInstances reads many: an identified caller must belong to the instance's
+// organization. An internal caller holds no identity and is served -- threads
+// and the orchestrator resolve instances on their own behalf. An instance may
+// always read itself, which no organization membership would grant it.
+func (s *Server) requireInstanceReadAccess(ctx context.Context, instance store.AgentInstance) error {
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasIdentity || identityID == instance.Meta.ID {
+		return nil
+	}
+	return s.requireOrganizationMember(ctx, identityID, instance.OrganizationID)
 }
 
 func (s *Server) ListInstances(ctx context.Context, req *agentsv1.ListInstancesRequest) (*agentsv1.ListInstancesResponse, error) {


### PR DESCRIPTION
`GetInstance` authorized nothing — any caller who knew an id read the instance, including its `organization_id` and the agent behind it. Instance ids are returned by other RPCs and appear in identities, so this was reachable rather than theoretical.

`ListInstances` was fixed already (it scopes through `organizationListScope`); this brings the single-entity read to the same terms, plus two carve-outs membership alone would get wrong:

- **Internal callers** (threads resolving an instance's organization, the orchestrator) carry no identity by design and hold no tuples — a check could only refuse them.
- **The instance itself** is not a member of its organization, so membership alone would deny it its own record.

Tests cover the guard directly: the RPC loads from a concrete store these tests don't stand up, and the guard takes the loaded instance as a value.