### PR TITLE
fix: keep FanoutInboxItem internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .gen/
+
+# devspace writes session logs into the working tree.
+.devspace/
+
+.DS_Store

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -322,7 +322,19 @@ func (s *Server) WriteInboxItem(ctx context.Context, req *agentsv1.WriteInboxIte
 	return &agentsv1.WriteInboxItemResponse{Item: toProtoInboxItem(item)}, nil
 }
 
+// FanoutInboxItem writes an item on behalf of whoever sent the message, so it
+// takes sender_id and thread_id from the caller rather than deriving them.
+// Threads calls it over the mesh with no identity of its own; a caller that
+// presents one is a user, app or agent, and must go through WriteInboxItem,
+// which checks can_write_inbox and that the sender is the caller. Without this
+// any authenticated caller could forge an item from any sender on any thread.
+// An AuthorizationPolicy narrows the unauthenticated path to Threads.
 func (s *Server) FanoutInboxItem(ctx context.Context, req *agentsv1.FanoutInboxItemRequest) (*agentsv1.FanoutInboxItemResponse, error) {
+	if _, hasIdentity, err := optionalIdentityUUIDFromContext(ctx); err != nil {
+		return nil, err
+	} else if hasIdentity {
+		return nil, status.Error(codes.PermissionDenied, "fanout is internal; use WriteInboxItem")
+	}
 	input, err := fanoutInboxInputFromRequest(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`FanoutInboxItem` takes `sender_id` and `thread_id` from the request rather than deriving them from the caller, and authorized nothing at all — so any caller that could reach the service could forge an inbox item from any sender on any thread.

The chart's `AuthorizationPolicy` already narrows the *unauthenticated* mesh path to the Threads service account, but an authenticated caller (user, app, agent) went straight through it.

Threads calls this over the mesh with no identity of its own, so presenting one is now refused. Those callers already have `WriteInboxItem`, which checks `can_write_inbox` and that the sender is the caller.