### PR TITLE
feat: agent default thread and final turn message

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -40,6 +40,8 @@ func toProtoAgent(agent store.Agent) *agentsv1.Agent {
 		Capabilities:   append([]string(nil), agent.Capabilities...),
 		Availability:   agentAvailabilityToProto(agent.Availability),
 		Resources:      toProtoComputeResources(agent.Resources),
+		DefaultThread:  agentDefaultThreadToProto(agent.DefaultThread),
+		FinalMessage:   agentFinalMessageToProto(agent.FinalMessage),
 	}
 	if agent.IdleTimeout != nil {
 		protoAgent.IdleTimeout = agent.IdleTimeout
@@ -261,6 +263,9 @@ func toProtoAgentInstance(instance store.AgentInstance) *agentsv1.AgentInstance 
 	}
 	if instance.PauseReason != nil {
 		protoInstance.PauseReason = instance.PauseReason
+	}
+	if instance.DefaultThreadID != nil {
+		protoInstance.DefaultThreadId = protoString(instance.DefaultThreadID.String())
 	}
 	return protoInstance
 }

--- a/internal/server/default_thread_test.go
+++ b/internal/server/default_thread_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+)
+
+// CreateInstance is the single enforcement point for the class policy: both
+// creation paths funnel through it and it already holds the class definition,
+// so Threads reports the circumstances and this decides what they mean.
+func TestResolveDefaultThread(t *testing.T) {
+	originThreadID := uuid.New()
+	explicitThreadID := uuid.New()
+
+	tests := []struct {
+		name   string
+		policy store.AgentDefaultThread
+		req    *agentsv1.CreateInstanceRequest
+		want   *uuid.UUID
+	}{
+		{
+			name:   "origin takes the thread that added the instance",
+			policy: store.AgentDefaultThreadOrigin,
+			req: &agentsv1.CreateInstanceRequest{
+				Context: &agentsv1.CreateInstanceContext{ThreadId: protoString(originThreadID.String())},
+			},
+			want: &originThreadID,
+		},
+		{
+			// "Do not infer a destination from whichever thread happened to add
+			// this instance" -- not "may never have one".
+			name:   "none infers nothing",
+			policy: store.AgentDefaultThreadNone,
+			req: &agentsv1.CreateInstanceRequest{
+				Context: &agentsv1.CreateInstanceContext{ThreadId: protoString(originThreadID.String())},
+			},
+			want: nil,
+		},
+		{
+			name:   "an explicit thread beats the policy",
+			policy: store.AgentDefaultThreadNone,
+			req: &agentsv1.CreateInstanceRequest{
+				DefaultThreadId: protoString(explicitThreadID.String()),
+				Context:         &agentsv1.CreateInstanceContext{ThreadId: protoString(originThreadID.String())},
+			},
+			want: &explicitThreadID,
+		},
+		{
+			name:   "an explicit thread beats an origin context too",
+			policy: store.AgentDefaultThreadOrigin,
+			req: &agentsv1.CreateInstanceRequest{
+				DefaultThreadId: protoString(explicitThreadID.String()),
+				Context:         &agentsv1.CreateInstanceContext{ThreadId: protoString(originThreadID.String())},
+			},
+			want: &explicitThreadID,
+		},
+		{
+			// agyn agents instantiate reports no circumstances at all.
+			name:   "no context leaves the default unset",
+			policy: store.AgentDefaultThreadOrigin,
+			req:    &agentsv1.CreateInstanceRequest{},
+			want:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := resolveDefaultThread(store.Agent{DefaultThread: test.policy}, test.req)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			switch {
+			case test.want == nil && got != nil:
+				t.Fatalf("expected no default thread, got %s", got)
+			case test.want != nil && got == nil:
+				t.Fatalf("expected %s, got none", test.want)
+			case test.want != nil && *got != *test.want:
+				t.Fatalf("expected %s, got %s", test.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveDefaultThreadRejectsMalformedIDs(t *testing.T) {
+	agent := store.Agent{DefaultThread: store.AgentDefaultThreadOrigin}
+
+	if _, err := resolveDefaultThread(agent, &agentsv1.CreateInstanceRequest{
+		DefaultThreadId: protoString("not-a-uuid"),
+	}); err == nil {
+		t.Fatal("expected an explicit malformed thread to be rejected")
+	}
+	if _, err := resolveDefaultThread(agent, &agentsv1.CreateInstanceRequest{
+		Context: &agentsv1.CreateInstanceContext{ThreadId: protoString("not-a-uuid")},
+	}); err == nil {
+		t.Fatal("expected a malformed context thread to be rejected")
+	}
+}
+
+// Unspecified is what a caller that has not chosen sends, and the documented
+// defaults preserve today's behaviour rather than erroring.
+func TestClassPolicyDefaults(t *testing.T) {
+	defaultThread, err := agentDefaultThreadFromProto(agentsv1.AgentDefaultThread_AGENT_DEFAULT_THREAD_UNSPECIFIED)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if defaultThread != store.AgentDefaultThreadOrigin {
+		t.Fatalf("expected origin, got %q", defaultThread)
+	}
+
+	finalMessage, err := agentFinalMessageFromProto(agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_UNSPECIFIED)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if finalMessage != store.AgentFinalMessageDiscard {
+		t.Fatalf("expected discard, got %q", finalMessage)
+	}
+}
+
+func TestClassPolicyRoundTrips(t *testing.T) {
+	for _, value := range []store.AgentDefaultThread{store.AgentDefaultThreadOrigin, store.AgentDefaultThreadNone} {
+		got, err := agentDefaultThreadFromProto(agentDefaultThreadToProto(value))
+		if err != nil || got != value {
+			t.Fatalf("expected %q to round trip, got %q (%v)", value, got, err)
+		}
+	}
+	for _, value := range []store.AgentFinalMessage{store.AgentFinalMessageDiscard, store.AgentFinalMessageDefaultThread} {
+		got, err := agentFinalMessageFromProto(agentFinalMessageToProto(value))
+		if err != nil || got != value {
+			t.Fatalf("expected %q to round trip, got %q (%v)", value, got, err)
+		}
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"regexp"
+	"strings"
 
 	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
 	identityv1 "github.com/agynio/agents/.gen/go/agynio/api/identity/v1"
@@ -44,14 +45,47 @@ func (s *Server) CreateInstance(ctx context.Context, req *agentsv1.CreateInstanc
 	if label != nil && !instanceSuffixPattern.MatchString(req.GetLabel()) {
 		return nil, status.Errorf(codes.InvalidArgument, "label must match %s", instanceSuffixPattern.String())
 	}
-	instance, err := s.createInstanceWithIdentity(ctx, agent, label)
+	defaultThreadID, err := resolveDefaultThread(agent, req)
+	if err != nil {
+		return nil, err
+	}
+	instance, err := s.createInstanceWithIdentity(ctx, agent, label, defaultThreadID)
 	if err != nil {
 		return nil, err
 	}
 	return &agentsv1.CreateInstanceResponse{Instance: toProtoAgentInstance(instance)}, nil
 }
 
-func (s *Server) createInstanceWithIdentity(ctx context.Context, agent store.Agent, label *string) (store.AgentInstance, error) {
+// resolveDefaultThread decides where this instance's untargeted messages will
+// go. Both creation paths funnel through here, and the class definition is
+// already loaded, so the policy is applied here rather than in Threads.
+//
+// An explicit default_thread_id is a deliberate act by a caller who knows the
+// destination, so it wins over the policy -- which governs only what the
+// platform infers when nobody said.
+func resolveDefaultThread(agent store.Agent, req *agentsv1.CreateInstanceRequest) (*uuid.UUID, error) {
+	if raw := strings.TrimSpace(req.GetDefaultThreadId()); raw != "" {
+		id, err := parseUUID(raw)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "default_thread_id: %v", err)
+		}
+		return &id, nil
+	}
+	if agent.DefaultThread == store.AgentDefaultThreadNone {
+		return nil, nil
+	}
+	raw := strings.TrimSpace(req.GetContext().GetThreadId())
+	if raw == "" {
+		return nil, nil
+	}
+	id, err := parseUUID(raw)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "context.thread_id: %v", err)
+	}
+	return &id, nil
+}
+
+func (s *Server) createInstanceWithIdentity(ctx context.Context, agent store.Agent, label *string, defaultThreadID *uuid.UUID) (store.AgentInstance, error) {
 	attempts := 1
 	if label == nil {
 		attempts = 5
@@ -169,6 +203,34 @@ func (s *Server) requireInstanceReadAccess(ctx context.Context, instance store.A
 		return nil
 	}
 	return s.requireOrganizationMember(ctx, identityID, instance.OrganizationID)
+}
+
+// SetInstanceDefaultThread moves where an instance's untargeted messages go.
+// The class policy governs only what the platform infers at creation; naming a
+// thread afterwards is a deliberate act, so it is allowed whatever the class
+// asked for. Unsetting leaves the instance with no destination.
+func (s *Server) SetInstanceDefaultThread(ctx context.Context, req *agentsv1.SetInstanceDefaultThreadRequest) (*agentsv1.SetInstanceDefaultThreadResponse, error) {
+	id, err := parseUUID(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	if err := s.requireManageInstance(ctx, id); err != nil {
+		return nil, err
+	}
+	var threadID *uuid.UUID
+	if raw := strings.TrimSpace(req.GetDefaultThreadId()); raw != "" {
+		parsed, err := parseUUID(raw)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "default_thread_id: %v", err)
+		}
+		threadID = &parsed
+	}
+	instance, err := s.store.SetAgentInstanceDefaultThread(ctx, id, threadID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	s.publishInstanceUpdated(ctx, instance)
+	return &agentsv1.SetInstanceDefaultThreadResponse{Instance: toProtoAgentInstance(instance)}, nil
 }
 
 func (s *Server) ListInstances(ctx context.Context, req *agentsv1.ListInstancesRequest) (*agentsv1.ListInstancesResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,6 +175,14 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 		environmentID = &resolved
 	}
 	nickname := req.GetNickname()
+	defaultThread, err := agentDefaultThreadFromProto(req.GetDefaultThread())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "default_thread: %v", err)
+	}
+	finalMessage, err := agentFinalMessageFromProto(req.GetFinalMessage())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "final_message: %v", err)
+	}
 	resources := toStoreComputeResources(req.GetResources())
 	agent, err := s.store.CreateAgent(ctx, organizationID, store.AgentInput{
 		Name:          req.GetName(),
@@ -190,6 +198,8 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 		Availability:  availability,
 		Resources:     resources,
 		EnvironmentID: environmentID,
+		DefaultThread: defaultThread,
+		FinalMessage:  finalMessage,
 	})
 	if err != nil {
 		return nil, toStatusError(err)
@@ -291,7 +301,7 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	capabilitiesProvided := req.Capabilities != nil
 	availabilityProvided := req.Availability != nil
 	environmentProvided := req.EnvironmentId != nil
-	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided && !environmentProvided {
+	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided && !environmentProvided && req.DefaultThread == nil && req.FinalMessage == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	if req.InitImage != nil && req.GetInitImage() == "" {
@@ -385,6 +395,21 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 			}
 			update.EnvironmentID = &environmentID
 		}
+	}
+
+	if req.DefaultThread != nil {
+		value, err := agentDefaultThreadFromProto(req.GetDefaultThread())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "default_thread: %v", err)
+		}
+		update.DefaultThread = &value
+	}
+	if req.FinalMessage != nil {
+		value, err := agentFinalMessageFromProto(req.GetFinalMessage())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "final_message: %v", err)
+		}
+		update.FinalMessage = &value
 	}
 
 	agent, err := s.store.UpdateAgent(ctx, id, update)
@@ -1750,6 +1775,54 @@ func agentAvailabilityToProto(availability store.AgentAvailability) agentsv1.Age
 		return agentsv1.AgentAvailability_AGENT_AVAILABILITY_PRIVATE
 	default:
 		panic(fmt.Sprintf("unknown agent availability %q", availability))
+	}
+}
+
+// agentDefaultThreadFromProto maps the class policy. UNSPECIFIED means the
+// caller did not choose, which is the documented default rather than an error:
+// origin is the only inference that composes for delegation.
+func agentDefaultThreadFromProto(value agentsv1.AgentDefaultThread) (store.AgentDefaultThread, error) {
+	switch value {
+	case agentsv1.AgentDefaultThread_AGENT_DEFAULT_THREAD_UNSPECIFIED,
+		agentsv1.AgentDefaultThread_AGENT_DEFAULT_THREAD_ORIGIN:
+		return store.AgentDefaultThreadOrigin, nil
+	case agentsv1.AgentDefaultThread_AGENT_DEFAULT_THREAD_NONE:
+		return store.AgentDefaultThreadNone, nil
+	default:
+		return "", fmt.Errorf("unknown value %d", value)
+	}
+}
+
+func agentDefaultThreadToProto(value store.AgentDefaultThread) agentsv1.AgentDefaultThread {
+	switch value {
+	case store.AgentDefaultThreadNone:
+		return agentsv1.AgentDefaultThread_AGENT_DEFAULT_THREAD_NONE
+	default:
+		return agentsv1.AgentDefaultThread_AGENT_DEFAULT_THREAD_ORIGIN
+	}
+}
+
+// agentFinalMessageFromProto maps what becomes of a turn's final text.
+// UNSPECIFIED is discard, so agents that already send explicitly do not start
+// posting everything twice.
+func agentFinalMessageFromProto(value agentsv1.AgentFinalMessage) (store.AgentFinalMessage, error) {
+	switch value {
+	case agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_UNSPECIFIED,
+		agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DISCARD:
+		return store.AgentFinalMessageDiscard, nil
+	case agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD:
+		return store.AgentFinalMessageDefaultThread, nil
+	default:
+		return "", fmt.Errorf("unknown value %d", value)
+	}
+}
+
+func agentFinalMessageToProto(value store.AgentFinalMessage) agentsv1.AgentFinalMessage {
+	switch value {
+	case store.AgentFinalMessageDefaultThread:
+		return agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DEFAULT_THREAD
+	default:
+		return agentsv1.AgentFinalMessage_AGENT_FINAL_MESSAGE_DISCARD
 	}
 }
 

--- a/internal/store/instances.go
+++ b/internal/store/instances.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	agentInstanceColumns = `ai.id, ai.agent_id, ai.organization_id, ai.label, ai.suffix, ai.state, ai.pause_reason, ai.last_activity_at, ai.created_at, ai.updated_at, ai.nickname`
+	agentInstanceColumns = `ai.id, ai.agent_id, ai.organization_id, ai.label, ai.suffix, ai.state, ai.pause_reason, ai.last_activity_at, ai.created_at, ai.updated_at, ai.nickname, ai.default_thread_id`
 	inboxItemColumns     = `id, agent_instance_id, source_kind, thread_id, message_id, sender_id, body, file_ids, accepted_at, acked_at`
 )
 
@@ -50,6 +50,7 @@ func scanAgentInstance(row pgx.Row) (AgentInstance, error) {
 	var instance AgentInstance
 	var label pgtype.Text
 	var pauseReason pgtype.Text
+	var defaultThreadID pgtype.UUID
 	if err := row.Scan(
 		&instance.Meta.ID,
 		&instance.AgentID,
@@ -62,11 +63,13 @@ func scanAgentInstance(row pgx.Row) (AgentInstance, error) {
 		&instance.Meta.CreatedAt,
 		&instance.Meta.UpdatedAt,
 		&instance.Nickname,
+		&defaultThreadID,
 	); err != nil {
 		return AgentInstance{}, err
 	}
 	instance.Label = stringPtrFromPg(label)
 	instance.PauseReason = stringPtrFromPg(pauseReason)
+	instance.DefaultThreadID = uuidPtrFromPg(defaultThreadID)
 	return instance, nil
 }
 
@@ -104,14 +107,15 @@ func scanInboxItem(row pgx.Row) (InboxItem, error) {
 func (s *Store) CreateAgentInstance(ctx context.Context, input AgentInstanceInput) (AgentInstance, error) {
 	var id uuid.UUID
 	err := s.pool.QueryRow(ctx,
-		`INSERT INTO agent_instances (agent_id, organization_id, label, suffix, nickname)
-			VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO agent_instances (agent_id, organization_id, label, suffix, nickname, default_thread_id)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			RETURNING id`,
 		input.AgentID,
 		input.OrganizationID,
 		input.Label,
 		input.Suffix,
 		input.Nickname,
+		input.DefaultThreadID,
 	).Scan(&id)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -139,6 +143,26 @@ func (s *Store) GetAgentInstance(ctx context.Context, id uuid.UUID) (AgentInstan
 		return AgentInstance{}, err
 	}
 	return instance, nil
+}
+
+// SetAgentInstanceDefaultThread moves where an instance's untargeted messages
+// go. A nil thread clears it, leaving the instance with no destination.
+func (s *Store) SetAgentInstanceDefaultThread(ctx context.Context, id uuid.UUID, threadID *uuid.UUID) (AgentInstance, error) {
+	var updatedID uuid.UUID
+	err := s.pool.QueryRow(ctx,
+		`UPDATE agent_instances SET default_thread_id = $1, updated_at = NOW()
+			WHERE id = $2 AND state <> $3 RETURNING id`,
+		threadID,
+		id,
+		AgentInstanceStateTerminated,
+	).Scan(&updatedID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return AgentInstance{}, NotFound("agent instance")
+		}
+		return AgentInstance{}, err
+	}
+	return s.GetAgentInstance(ctx, updatedID)
 }
 
 func (s *Store) PauseAgentInstance(ctx context.Context, id uuid.UUID, reason string) (AgentInstance, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, created_at, updated_at`
+	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message, created_at, updated_at`
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, organization_id, image_pull_secret_id, agent_id, mcp_id, hook_id, environment_id, created_at, updated_at`
@@ -100,6 +100,8 @@ func scanAgent(row pgx.Row) (Agent, error) {
 		&agent.Resources.LimitsCPU,
 		&agent.Resources.LimitsMemory,
 		&environmentID,
+		&agent.DefaultThread,
+		&agent.FinalMessage,
 		&agent.Meta.CreatedAt,
 		&agent.Meta.UpdatedAt,
 	); err != nil {
@@ -376,8 +378,8 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		return Agent{}, err
 	}
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 		 RETURNING %s`, agentColumns),
 		organizationID,
 		input.Name,
@@ -396,6 +398,8 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		input.Resources.LimitsCPU,
 		input.Resources.LimitsMemory,
 		input.EnvironmentID,
+		input.DefaultThread,
+		input.FinalMessage,
 	)
 	agent, err := scanAgent(row)
 	if err != nil {
@@ -472,6 +476,12 @@ func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdat
 	}
 	if update.ClearEnvironmentID {
 		builder.addNull("environment_id")
+	}
+	if update.DefaultThread != nil {
+		builder.add("default_thread", *update.DefaultThread)
+	}
+	if update.FinalMessage != nil {
+		builder.add("final_message", *update.FinalMessage)
 	}
 
 	if builder.empty() {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -38,7 +38,33 @@ type Agent struct {
 	// written before environments existed, which still carry Image and
 	// Resources of their own.
 	EnvironmentID *uuid.UUID
+	// Where an instance's default thread comes from when the platform creates
+	// it, and what becomes of a turn's final text. Both describe how the agent
+	// is written, so they belong to the class rather than to an instance.
+	DefaultThread AgentDefaultThread
+	FinalMessage  AgentFinalMessage
 }
+
+// AgentDefaultThread governs the automatic creation path only. Naming a thread
+// explicitly is always allowed, so none means "infer nothing", not "never".
+type AgentDefaultThread string
+
+const (
+	// AgentDefaultThreadOrigin takes the thread that added the instance.
+	// Delegation creates sub-threads downward, so the origin is the thread the
+	// instance owes an answer to.
+	AgentDefaultThreadOrigin AgentDefaultThread = "origin"
+	AgentDefaultThreadNone   AgentDefaultThread = "none"
+)
+
+// AgentFinalMessage decides whether the text an agent CLI produces at the end
+// of a turn is a deliverable or an internal artifact.
+type AgentFinalMessage string
+
+const (
+	AgentFinalMessageDiscard       AgentFinalMessage = "discard"
+	AgentFinalMessageDefaultThread AgentFinalMessage = "default_thread"
+)
 
 type AgentAvailability string
 
@@ -96,14 +122,18 @@ type AgentInstance struct {
 	PauseReason    *string
 	LastActivityAt time.Time
 	Nickname       string
+	// Where this instance's untargeted messages go. Null when the class asked
+	// for no inference and nobody has named one since.
+	DefaultThreadID *uuid.UUID
 }
 
 type AgentInstanceInput struct {
-	AgentID        uuid.UUID
-	OrganizationID uuid.UUID
-	Label          *string
-	Suffix         string
-	Nickname       string
+	AgentID         uuid.UUID
+	OrganizationID  uuid.UUID
+	Label           *string
+	Suffix          string
+	Nickname        string
+	DefaultThreadID *uuid.UUID
 }
 
 type AgentInstanceFilter struct {
@@ -267,6 +297,8 @@ type AgentInput struct {
 	Availability  AgentAvailability
 	Resources     ComputeResources
 	EnvironmentID *uuid.UUID
+	DefaultThread AgentDefaultThread
+	FinalMessage  AgentFinalMessage
 }
 
 type AgentUpdate struct {
@@ -286,6 +318,8 @@ type AgentUpdate struct {
 	// agent may have none, so the two cases are distinct.
 	EnvironmentID      *uuid.UUID
 	ClearEnvironmentID bool
+	DefaultThread      *AgentDefaultThread
+	FinalMessage       *AgentFinalMessage
 }
 
 type VolumeInput struct {

--- a/migrations/0019_agent_default_thread.sql
+++ b/migrations/0019_agent_default_thread.sql
@@ -1,0 +1,26 @@
+-- An instance had no record of the thread it was created to serve, so the text
+-- an agent CLI produces at the end of a turn had nowhere to go.
+--
+-- Nullable: an instance whose class asked for no inference, and that nobody has
+-- named a thread for since, legitimately has none. Its untargeted sends are
+-- rejected rather than guessed at.
+--
+-- No foreign key. Threads are another service's data; this records a reference
+-- across that boundary the way thread participants already do.
+ALTER TABLE agent_instances
+    ADD COLUMN default_thread_id UUID;
+
+-- Where an instance's default thread comes from when the platform creates it,
+-- and what becomes of a turn's final text. Both describe how an agent is
+-- written rather than any one instance, so they sit on the class.
+--
+-- The defaults preserve today's behaviour: origin is the only inference that
+-- composes for delegation, and discard keeps agents that already send
+-- explicitly from posting everything twice.
+ALTER TABLE agents
+    ADD COLUMN default_thread TEXT NOT NULL DEFAULT 'origin',
+    ADD COLUMN final_message TEXT NOT NULL DEFAULT 'discard';
+
+ALTER TABLE agents
+    ADD CONSTRAINT agents_default_thread_check CHECK (default_thread IN ('origin', 'none')),
+    ADD CONSTRAINT agents_final_message_check CHECK (final_message IN ('discard', 'default_thread'));


### PR DESCRIPTION
Agents half of [2026-08-01-agent-default-thread](https://github.com/agynio/architecture/blob/main/changes/2026-08-01-agent-default-thread.md). Needs api#168 (merged).

- **`agent_instances.default_thread_id`** — nullable, because an instance whose class asked for no inference legitimately has none. Its untargeted sends get refused rather than guessed at. No foreign key: threads are another service's data.
- **`agents.default_thread` / `agents.final_message`** — both describe how an agent is *written*, not any one instance, so they sit on the class. Defaults `origin` and `discard` preserve today's behaviour.
- **`CreateInstance` applies the policy.** Both creation paths funnel through it and it already holds the class definition, so Threads reports circumstances in `context` and this decides what they mean. An explicit `default_thread_id` bypasses the policy — the policy governs only what the platform infers when nobody said.
- **`SetInstanceDefaultThread`**, guarded by `can_manage`.

Still to come in other repos: Threads passing `context.thread_id` on class-on-add and resolving an omitted `thread_id`, and agynd posting the final text.