### PR TITLE
fix: clear every tuple on a deleted agent instance

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -22,6 +22,7 @@ const (
 type AuthorizationWriter interface {
 	Check(ctx context.Context, req *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
 	Write(ctx context.Context, req *authorizationv1.WriteRequest, opts ...grpc.CallOption) (*authorizationv1.WriteResponse, error)
+	Read(ctx context.Context, req *authorizationv1.ReadRequest, opts ...grpc.CallOption) (*authorizationv1.ReadResponse, error)
 }
 
 func (s *Server) requireOrganizationMember(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
@@ -219,12 +220,45 @@ func (s *Server) addAgentInstanceAuthorization(ctx context.Context, instance sto
 	}, nil)
 }
 
+// removeAgentInstanceAuthorization clears every tuple on the instance, not just
+// the three written at creation. can_write_inbox is granted to identities and
+// groups afterwards, and those grants would otherwise outlive the instance they
+// name.
+//
+// The instance's thread participations also name it as the user, but those
+// belong to the threads and are removed with them.
 func (s *Server) removeAgentInstanceAuthorization(ctx context.Context, instance store.AgentInstance) error {
-	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{
-		agentInstanceClassTuple(instance.Meta.ID, instance.AgentID),
-		agentInstanceOrganizationTuple(instance.Meta.ID, instance.OrganizationID),
-		agentInstanceIdentityOrganizationMembershipTuple(instance.Meta.ID, instance.OrganizationID),
-	})
+	deletes := make([]*authorizationv1.TupleKey, 0, 4)
+	object := agentInstancePrefix + instance.Meta.ID.String()
+	pageToken := ""
+	for {
+		response, err := s.authz.Read(ctx, &authorizationv1.ReadRequest{
+			TupleKey:  &authorizationv1.TupleKey{Object: object},
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return err
+		}
+		for _, tuple := range response.GetTuples() {
+			key := tuple.GetKey()
+			if key == nil {
+				continue
+			}
+			deletes = append(deletes, &authorizationv1.TupleKey{
+				User:     key.GetUser(),
+				Relation: key.GetRelation(),
+				Object:   key.GetObject(),
+			})
+		}
+		pageToken = response.GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
+	}
+	// Organization membership names the instance as the user rather than the
+	// object, so it is not among the tuples read above and is added by hand.
+	deletes = append(deletes, agentInstanceIdentityOrganizationMembershipTuple(instance.Meta.ID, instance.OrganizationID))
+	return s.writeAuthorization(ctx, nil, deletes)
 }
 
 func (s *Server) addSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID) error {

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -272,6 +272,9 @@ func TestSandboxListFilterRequiresListPermissionForOtherOwner(t *testing.T) {
 type recordingAuthorizationWriter struct {
 	writes []*authorizationv1.WriteRequest
 	checks []*authorizationv1.CheckRequest
+	reads  []*authorizationv1.ReadRequest
+	// storedTuples is what Read returns, filtered by the requested object.
+	storedTuples []*authorizationv1.TupleKey
 	// allowedObjects, when set, are the only objects a check is allowed against,
 	// which is how a caller holding tuples somewhere else is expressed. A nil map
 	// allows every check.
@@ -289,6 +292,19 @@ func (w *recordingAuthorizationWriter) Check(_ context.Context, req *authorizati
 	}
 	allowed := w.allowedObjects == nil || w.allowedObjects[req.GetTupleKey().GetObject()]
 	return &authorizationv1.CheckResponse{Allowed: allowed}, nil
+}
+
+// Read returns the tuples the fake was seeded with, so instance cleanup can be
+// exercised without an authorization server.
+func (w *recordingAuthorizationWriter) Read(_ context.Context, req *authorizationv1.ReadRequest, _ ...grpc.CallOption) (*authorizationv1.ReadResponse, error) {
+	w.reads = append(w.reads, req)
+	tuples := make([]*authorizationv1.Tuple, 0, len(w.storedTuples))
+	for _, key := range w.storedTuples {
+		if req.GetTupleKey().GetObject() == "" || key.GetObject() == req.GetTupleKey().GetObject() {
+			tuples = append(tuples, &authorizationv1.Tuple{Key: key})
+		}
+	}
+	return &authorizationv1.ReadResponse{Tuples: tuples}, nil
 }
 
 func (w *recordingAuthorizationWriter) Write(_ context.Context, req *authorizationv1.WriteRequest, _ ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
@@ -375,14 +391,32 @@ func TestAddAgentInstanceAuthorizationWritesClassOrgMembership(t *testing.T) {
 	assertTuples(t, request.GetDeletes(), nil)
 }
 
-func TestRemoveAgentInstanceAuthorizationDeletesClassOrgMembership(t *testing.T) {
-	authz := &recordingAuthorizationWriter{}
-	server := &Server{authz: authz}
+func TestRemoveAgentInstanceAuthorizationDeletesEveryTupleOnTheInstance(t *testing.T) {
 	instance := store.AgentInstance{
 		Meta:           store.EntityMeta{ID: uuid.New()},
 		AgentID:        uuid.New(),
 		OrganizationID: uuid.New(),
 	}
+	// can_write_inbox is granted after creation, so deleting only what creation
+	// wrote leaves grants naming an instance that no longer exists.
+	inboxGrant := &authorizationv1.TupleKey{
+		User:     identityPrefix + uuid.NewString(),
+		Relation: "can_write_inbox",
+		Object:   agentInstancePrefix + instance.Meta.ID.String(),
+	}
+	other := &authorizationv1.TupleKey{
+		User:     identityPrefix + uuid.NewString(),
+		Relation: "can_write_inbox",
+		Object:   agentInstancePrefix + uuid.NewString(),
+	}
+	authz := &recordingAuthorizationWriter{storedTuples: []*authorizationv1.TupleKey{
+		agentInstanceClassTuple(instance.Meta.ID, instance.AgentID),
+		agentInstanceOrganizationTuple(instance.Meta.ID, instance.OrganizationID),
+		agentInstanceIdentityOrganizationMembershipTuple(instance.Meta.ID, instance.OrganizationID),
+		inboxGrant,
+		other,
+	}}
+	server := &Server{authz: authz}
 
 	if err := server.removeAgentInstanceAuthorization(context.Background(), instance); err != nil {
 		t.Fatalf("remove agent instance authorization: %v", err)
@@ -390,9 +424,30 @@ func TestRemoveAgentInstanceAuthorizationDeletesClassOrgMembership(t *testing.T)
 
 	request := singleWriteRequest(t, authz)
 	assertTuples(t, request.GetWrites(), nil)
+	// Everything on this instance, and nothing belonging to another.
 	assertTuples(t, request.GetDeletes(), []*authorizationv1.TupleKey{
 		agentInstanceClassTuple(instance.Meta.ID, instance.AgentID),
 		agentInstanceOrganizationTuple(instance.Meta.ID, instance.OrganizationID),
+		inboxGrant,
+		agentInstanceIdentityOrganizationMembershipTuple(instance.Meta.ID, instance.OrganizationID),
+	})
+}
+
+// An instance nobody granted anything on still gives up its organization
+// membership, which is written at creation and read back from a different
+// object.
+func TestRemoveAgentInstanceAuthorizationAlwaysDropsMembership(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	instance := store.AgentInstance{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+	}
+
+	if err := server.removeAgentInstanceAuthorization(context.Background(), instance); err != nil {
+		t.Fatalf("remove agent instance authorization: %v", err)
+	}
+	assertTuples(t, singleWriteRequest(t, authz).GetDeletes(), []*authorizationv1.TupleKey{
 		agentInstanceIdentityOrganizationMembershipTuple(instance.Meta.ID, instance.OrganizationID),
 	})
 }

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -309,6 +309,10 @@ func (noopAuthorizationWriter) Check(context.Context, *authorizationv1.CheckRequ
 	return &authorizationv1.CheckResponse{Allowed: true}, nil
 }
 
+func (noopAuthorizationWriter) Read(context.Context, *authorizationv1.ReadRequest, ...grpc.CallOption) (*authorizationv1.ReadResponse, error) {
+	return &authorizationv1.ReadResponse{}, nil
+}
+
 func (noopAuthorizationWriter) Write(context.Context, *authorizationv1.WriteRequest, ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
 	return &authorizationv1.WriteResponse{}, nil
 }


### PR DESCRIPTION
`removeAgentInstanceAuthorization` deleted only the three tuples creation wrote. `can_write_inbox` is granted *after* creation — to identities and groups allowed to write that inbox — so those grants outlived the instance they named. [authz.md:185](https://github.com/agynio/architecture/blob/main/architecture/authz.md) requires every tuple on the object to go.

The tuples on `agent_instance:<id>` are now read back and deleted as a set.

One exception is handled by hand: organization membership names the instance as the *user* rather than the object, so a read scoped to the object never returns it. My first attempt missed that and the existing test caught it. Thread participations also name the instance as the user, but those belong to the threads and are removed with them.