### PR TITLE
fix: let an instance name itself

### DIFF
--- a/internal/server/instance_nickname_test.go
+++ b/internal/server/instance_nickname_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	identityv1 "github.com/agynio/agents/.gen/go/agynio/api/identity/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type recordingIdentityWriter struct {
+	noopIdentityWriter
+	caller string
+}
+
+func (r *recordingIdentityWriter) SetNickname(ctx context.Context, _ *identityv1.SetNicknameRequest, _ ...grpc.CallOption) (*identityv1.SetNicknameResponse, error) {
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if values := md.Get("x-identity-id"); len(values) == 1 {
+			r.caller = values[0]
+		}
+	}
+	return &identityv1.SetNicknameResponse{}, nil
+}
+
+// Identity lets a caller name itself with plain organization membership, and
+// name anyone else only with can_manage_members. An instance is created from a
+// thread, so forwarding the caller would present an ordinary participant --
+// who has neither -- and no instance could ever be named.
+func TestSetAgentInstanceNicknameNamesItself(t *testing.T) {
+	identity := &recordingIdentityWriter{}
+	server := New(&store.Store{}, noopAuthorizationWriter{}, identity, noopNotificationsClient{})
+
+	instance := store.AgentInstance{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Nickname:       "helper",
+		Suffix:         "a1b2c3d4",
+	}
+
+	// A caller is present and is deliberately someone else: the instance still
+	// has to be the one named.
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", uuid.NewString()))
+	if err := server.setAgentInstanceNickname(ctx, instance); err != nil {
+		t.Fatalf("setAgentInstanceNickname failed: %v", err)
+	}
+	if identity.caller != instance.Meta.ID.String() {
+		t.Fatalf("expected the instance %s to name itself, got %q", instance.Meta.ID, identity.caller)
+	}
+}
+
+// The Orchestrator reaches instance creation over the mesh with no caller at
+// all, which used to fail before the nickname call was even made.
+func TestSetAgentInstanceNicknameWithoutACaller(t *testing.T) {
+	identity := &recordingIdentityWriter{}
+	server := New(&store.Store{}, noopAuthorizationWriter{}, identity, noopNotificationsClient{})
+
+	instance := store.AgentInstance{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Nickname:       "helper",
+		Suffix:         "a1b2c3d4",
+	}
+	if err := server.setAgentInstanceNickname(context.Background(), instance); err != nil {
+		t.Fatalf("setAgentInstanceNickname failed: %v", err)
+	}
+	if identity.caller != instance.Meta.ID.String() {
+		t.Fatalf("expected the instance %s to name itself, got %q", instance.Meta.ID, identity.caller)
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agynio/agents/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -160,12 +161,19 @@ func (s *Server) registerAgentInstanceIdentity(ctx context.Context, instanceID u
 	return err
 }
 
+// setAgentInstanceNickname names the instance as the instance, not as whoever
+// asked for it.
+//
+// Identity lets a caller set its own nickname with plain organization
+// membership, and anyone else's only with can_manage_members. An instance is
+// created from a thread, so the caller is an ordinary participant who has
+// neither -- and the Orchestrator reaches this with no caller at all. The
+// instance itself holds an organization membership tuple by this point
+// (addAgentInstanceAuthorization runs first), so it is the one caller that is
+// always allowed.
 func (s *Server) setAgentInstanceNickname(ctx context.Context, instance store.AgentInstance) error {
-	identityCtx, err := identityOutgoingContext(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = s.identity.SetNickname(identityCtx, &identityv1.SetNicknameRequest{
+	identityCtx := metadata.AppendToOutgoingContext(ctx, "x-identity-id", instance.Meta.ID.String())
+	_, err := s.identity.SetNickname(identityCtx, &identityv1.SetNicknameRequest{
 		OrganizationId: instance.OrganizationID.String(),
 		IdentityId:     instance.Meta.ID.String(),
 		Nickname:       instance.Nickname,


### PR DESCRIPTION
`identity.SetNickname` authorizes on who the caller is:

- **caller == subject** → plain `member` on the organization is enough
- **caller != subject** → needs `can_manage_members` or `can_add_member`

`setAgentInstanceNickname` forwarded the *caller's* identity. Instances are created from a thread, so that caller is an ordinary participant with neither of those permissions — and the Orchestrator reaches instance creation over the mesh with no caller at all, failing in `identityOutgoingContext` before the call was even made.

The instance itself already holds an organization membership tuple at this point (`addAgentInstanceAuthorization` runs before the nickname is set, and `registerAgentInstanceIdentity` before that), so it is the one caller that is always allowed. It now names itself — the same shape as [apps#28](https://github.com/agynio/apps/pull/28).

**Why no test caught it:** this fix has existed only as a patch the E2E workflow applied to `instances.go` at build time. The workflow now fails outright — `agents instances.go import block not found` — because the anchor moved when `"strings"` was added to the imports. Two tests pin the behaviour instead; both fail on `main`.

Removing that patch from the E2E workflow is a follow-up in agynio/e2e.