### PR TITLE
feat: pause instances that have sat idle too long

### DIFF
--- a/cmd/agents-service/main.go
+++ b/cmd/agents-service/main.go
@@ -78,7 +78,13 @@ func run() error {
 	}()
 	notificationsClient := notificationsv1.NewNotificationsServiceClient(notificationsConn)
 
-	agentsv1.RegisterAgentsServiceServer(grpcServer, server.New(store.New(pool), authzClient, identity, notificationsClient))
+	agentsService := server.New(store.New(pool), authzClient, identity, notificationsClient)
+	agentsv1.RegisterAgentsServiceServer(grpcServer, agentsService)
+
+	// Instances whose class sets an idle limit are paused once they pass it.
+	// Started before Serve so a service that never receives a request still
+	// reclaims what earlier runs left behind.
+	go agentsService.RunInstanceIdleGC(ctx, cfg.InstanceIdleGCInterval)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 type Config struct {
@@ -11,10 +12,21 @@ type Config struct {
 	AuthorizationServiceAddress string
 	IdentityServiceAddress      string
 	NotificationsServiceAddress string
+	// How often idle instances are swept. Configurable mainly so a test
+	// deployment can watch the sweep without waiting a minute for it.
+	InstanceIdleGCInterval time.Duration
 }
 
 func FromEnv() (Config, error) {
 	cfg := Config{}
+	cfg.InstanceIdleGCInterval = time.Minute
+	if raw := os.Getenv("INSTANCE_IDLE_GC_INTERVAL"); raw != "" {
+		interval, err := time.ParseDuration(raw)
+		if err != nil {
+			return Config{}, fmt.Errorf("INSTANCE_IDLE_GC_INTERVAL: %w", err)
+		}
+		cfg.InstanceIdleGCInterval = interval
+	}
 	cfg.GRPCAddress = os.Getenv("GRPC_ADDRESS")
 	if cfg.GRPCAddress == "" {
 		cfg.GRPCAddress = ":50051"

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -43,6 +43,9 @@ func toProtoAgent(agent store.Agent) *agentsv1.Agent {
 		DefaultThread:  agentDefaultThreadToProto(agent.DefaultThread),
 		FinalMessage:   agentFinalMessageToProto(agent.FinalMessage),
 	}
+	if agent.InstanceIdleTTL != nil {
+		protoAgent.InstanceIdleTtl = agent.InstanceIdleTTL
+	}
 	if agent.IdleTimeout != nil {
 		protoAgent.IdleTimeout = agent.IdleTimeout
 	}

--- a/internal/server/instance_gc.go
+++ b/internal/server/instance_gc.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+)
+
+// PauseReasonIdleTTLExceeded is recorded on instances the GC pauses, so a
+// person looking at a paused instance can tell "nobody used this" apart from
+// "something went wrong".
+const PauseReasonIdleTTLExceeded = "idle_ttl_exceeded"
+
+const (
+	defaultIdleGCInterval = time.Minute
+	idleGCBatchSize       = 500
+)
+
+// IdleGCStore is the store behaviour the idle sweep needs.
+type IdleGCStore interface {
+	ListIdleGCCandidates(ctx context.Context, limit int) ([]store.IdleInstance, error)
+	PauseAgentInstance(ctx context.Context, id uuid.UUID, reason string) (store.AgentInstance, error)
+}
+
+// RunInstanceIdleGC pauses instances that have sat idle longer than their class
+// allows, until ctx is cancelled.
+//
+// Paused, not terminated: the instance keeps its thread, its default thread and
+// its inbox, so ResumeInstance picks up whatever arrived while it was away.
+// What the sweep reclaims is the workload behind it, which the Orchestrator
+// stops once the instance is no longer active.
+func (s *Server) RunInstanceIdleGC(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultIdleGCInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if paused, err := sweepIdleInstances(ctx, s.store); err != nil {
+				// Logged, not fatal: a sweep that fails is retried on the next
+				// tick, and an instance staying active a minute longer than its
+				// limit is not worth taking the service down for.
+				log.Printf("instance idle gc: %v", err)
+			} else if paused > 0 {
+				log.Printf("instance idle gc: paused %d idle instance(s)", paused)
+			}
+		}
+	}
+}
+
+// sweepIdleInstances takes the store as an interface so the decision -- which
+// instances are past their limit -- can be tested without a database.
+func sweepIdleInstances(ctx context.Context, instances IdleGCStore) (int, error) {
+	candidates, err := instances.ListIdleGCCandidates(ctx, idleGCBatchSize)
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	paused := 0
+	for _, candidate := range candidates {
+		ttl, err := time.ParseDuration(candidate.IdleTTL)
+		if err != nil {
+			// The column is free text and nothing enforces it retroactively. A
+			// class with an unreadable limit is left alone rather than swept on
+			// a guess.
+			log.Printf("instance idle gc: instance %s has an unreadable idle ttl %q: %v", candidate.ID, candidate.IdleTTL, err)
+			continue
+		}
+		if ttl <= 0 || now.Sub(candidate.LastActivityAt) < ttl {
+			continue
+		}
+		if _, err := instances.PauseAgentInstance(ctx, candidate.ID, PauseReasonIdleTTLExceeded); err != nil {
+			// One instance failing to pause -- resumed a moment ago, deleted
+			// under us -- says nothing about the rest of the batch.
+			log.Printf("instance idle gc: pause %s: %v", candidate.ID, err)
+			continue
+		}
+		paused++
+	}
+	return paused, nil
+}

--- a/internal/server/instance_gc_test.go
+++ b/internal/server/instance_gc_test.go
@@ -114,3 +114,23 @@ func TestSweepIdleInstancesContinuesPastAFailure(t *testing.T) {
 		t.Fatal("the batch stopped at the first failure")
 	}
 }
+
+// The value reaching the column is a Go duration, and the sweep parses it with
+// time.ParseDuration -- so what CreateAgent accepts and what the sweep can read
+// have to be the same set. "1h30m" is the case that matters: a valid duration
+// Postgres would not read as an interval.
+func TestInstanceIdleTTLValidation(t *testing.T) {
+	for _, value := range []string{"30m", "1h30m", "6h", "90s"} {
+		if err := validateDurationString(value); err != nil {
+			t.Fatalf("%q should be accepted: %v", value, err)
+		}
+		if _, err := time.ParseDuration(value); err != nil {
+			t.Fatalf("%q is accepted but the sweep cannot parse it: %v", value, err)
+		}
+	}
+	for _, value := range []string{"forever", "30", "", "1 hour"} {
+		if err := validateDurationString(value); err == nil {
+			t.Fatalf("%q should be rejected", value)
+		}
+	}
+}

--- a/internal/server/instance_gc_test.go
+++ b/internal/server/instance_gc_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+)
+
+type fakeIdleGCStore struct {
+	candidates []store.IdleInstance
+	listErr    error
+	paused     map[uuid.UUID]string
+	pauseErr   map[uuid.UUID]error
+}
+
+func (f *fakeIdleGCStore) ListIdleGCCandidates(context.Context, int) ([]store.IdleInstance, error) {
+	return f.candidates, f.listErr
+}
+
+func (f *fakeIdleGCStore) PauseAgentInstance(_ context.Context, id uuid.UUID, reason string) (store.AgentInstance, error) {
+	if err, ok := f.pauseErr[id]; ok {
+		return store.AgentInstance{}, err
+	}
+	if f.paused == nil {
+		f.paused = map[uuid.UUID]string{}
+	}
+	f.paused[id] = reason
+	return store.AgentInstance{}, nil
+}
+
+func TestSweepIdleInstances(t *testing.T) {
+	idle := uuid.New()
+	busy := uuid.New()
+	exactly := uuid.New()
+	now := time.Now().UTC()
+
+	instances := &fakeIdleGCStore{candidates: []store.IdleInstance{
+		{ID: idle, LastActivityAt: now.Add(-2 * time.Hour), IdleTTL: "30m"},
+		{ID: busy, LastActivityAt: now.Add(-time.Minute), IdleTTL: "30m"},
+		// A Go duration Postgres would not read as an interval, which is why
+		// the comparison is done here rather than in the query.
+		{ID: exactly, LastActivityAt: now.Add(-2 * time.Hour), IdleTTL: "1h30m"},
+	}}
+
+	paused, err := sweepIdleInstances(context.Background(), instances)
+	if err != nil {
+		t.Fatalf("sweepIdleInstances failed: %v", err)
+	}
+	if paused != 2 {
+		t.Fatalf("expected 2 instances paused, got %d", paused)
+	}
+	if reason := instances.paused[idle]; reason != PauseReasonIdleTTLExceeded {
+		t.Fatalf("expected %q, got %q", PauseReasonIdleTTLExceeded, reason)
+	}
+	if _, ok := instances.paused[busy]; ok {
+		t.Fatal("an instance active a minute ago was paused")
+	}
+	if _, ok := instances.paused[exactly]; !ok {
+		t.Fatal("expected the 1h30m limit to be read as a Go duration")
+	}
+}
+
+// The column is free text and nothing enforces it retroactively, so a class
+// with an unreadable limit is left alone rather than swept on a guess.
+func TestSweepIdleInstancesSkipsUnreadableTTL(t *testing.T) {
+	bad := uuid.New()
+	good := uuid.New()
+	now := time.Now().UTC()
+
+	instances := &fakeIdleGCStore{candidates: []store.IdleInstance{
+		{ID: bad, LastActivityAt: now.Add(-99 * time.Hour), IdleTTL: "forever"},
+		{ID: good, LastActivityAt: now.Add(-99 * time.Hour), IdleTTL: "1h"},
+	}}
+
+	paused, err := sweepIdleInstances(context.Background(), instances)
+	if err != nil {
+		t.Fatalf("sweepIdleInstances failed: %v", err)
+	}
+	if paused != 1 {
+		t.Fatalf("expected 1 instance paused, got %d", paused)
+	}
+	if _, ok := instances.paused[bad]; ok {
+		t.Fatal("an instance with an unreadable ttl was paused")
+	}
+}
+
+// One instance failing to pause -- resumed a moment ago, deleted under us --
+// says nothing about the rest of the batch.
+func TestSweepIdleInstancesContinuesPastAFailure(t *testing.T) {
+	first := uuid.New()
+	second := uuid.New()
+	now := time.Now().UTC()
+
+	instances := &fakeIdleGCStore{
+		candidates: []store.IdleInstance{
+			{ID: first, LastActivityAt: now.Add(-time.Hour), IdleTTL: "1m"},
+			{ID: second, LastActivityAt: now.Add(-time.Hour), IdleTTL: "1m"},
+		},
+		pauseErr: map[uuid.UUID]error{first: errors.New("gone")},
+	}
+
+	paused, err := sweepIdleInstances(context.Background(), instances)
+	if err != nil {
+		t.Fatalf("sweepIdleInstances failed: %v", err)
+	}
+	if paused != 1 {
+		t.Fatalf("expected 1 instance paused, got %d", paused)
+	}
+	if _, ok := instances.paused[second]; !ok {
+		t.Fatal("the batch stopped at the first failure")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -164,6 +164,17 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	if err := validateDurationString(idleTimeout); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "idle_timeout: %v", err)
 	}
+	// Unset rather than defaulted: no limit is the honest answer for an agent
+	// whose author did not name one, and it is what every agent predating the
+	// column already behaves as.
+	var instanceIdleTTL *string
+	if req.InstanceIdleTtl != nil {
+		value := req.GetInstanceIdleTtl()
+		if err := validateDurationString(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "instance_idle_ttl: %v", err)
+		}
+		instanceIdleTTL = &value
+	}
 	// Optional: an agent may name no environment and run from the deprecated
 	// inline image and resources instead.
 	var environmentID *uuid.UUID
@@ -185,21 +196,22 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 	}
 	resources := toStoreComputeResources(req.GetResources())
 	agent, err := s.store.CreateAgent(ctx, organizationID, store.AgentInput{
-		Name:          req.GetName(),
-		Nickname:      nickname,
-		Role:          req.GetRole(),
-		Model:         modelID,
-		Description:   req.GetDescription(),
-		Configuration: req.GetConfiguration(),
-		Image:         req.GetImage(),
-		InitImage:     req.GetInitImage(),
-		IdleTimeout:   &idleTimeout,
-		Capabilities:  append([]string(nil), req.GetCapabilities()...),
-		Availability:  availability,
-		Resources:     resources,
-		EnvironmentID: environmentID,
-		DefaultThread: defaultThread,
-		FinalMessage:  finalMessage,
+		Name:            req.GetName(),
+		Nickname:        nickname,
+		Role:            req.GetRole(),
+		Model:           modelID,
+		Description:     req.GetDescription(),
+		Configuration:   req.GetConfiguration(),
+		Image:           req.GetImage(),
+		InitImage:       req.GetInitImage(),
+		IdleTimeout:     &idleTimeout,
+		Capabilities:    append([]string(nil), req.GetCapabilities()...),
+		Availability:    availability,
+		Resources:       resources,
+		EnvironmentID:   environmentID,
+		DefaultThread:   defaultThread,
+		FinalMessage:    finalMessage,
+		InstanceIdleTTL: instanceIdleTTL,
 	})
 	if err != nil {
 		return nil, toStatusError(err)
@@ -301,7 +313,7 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 	capabilitiesProvided := req.Capabilities != nil
 	availabilityProvided := req.Availability != nil
 	environmentProvided := req.EnvironmentId != nil
-	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided && !environmentProvided && req.DefaultThread == nil && req.FinalMessage == nil {
+	if req.Name == nil && req.Nickname == nil && req.Role == nil && req.Model == nil && req.Description == nil && req.Configuration == nil && req.Image == nil && req.InitImage == nil && req.IdleTimeout == nil && req.Resources == nil && !capabilitiesProvided && !availabilityProvided && !environmentProvided && req.DefaultThread == nil && req.FinalMessage == nil && req.InstanceIdleTtl == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	if req.InitImage != nil && req.GetInitImage() == "" {
@@ -403,6 +415,18 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 			return nil, status.Errorf(codes.InvalidArgument, "default_thread: %v", err)
 		}
 		update.DefaultThread = &value
+	}
+	if req.InstanceIdleTtl != nil {
+		value := req.GetInstanceIdleTtl()
+		// An empty string clears it -- "this agent no longer expires its
+		// instances" has to be expressible, and validateDurationString would
+		// reject "" as a duration.
+		if value != "" {
+			if err := validateDurationString(value); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "instance_idle_ttl: %v", err)
+			}
+		}
+		update.InstanceIdleTTL = &value
 	}
 	if req.FinalMessage != nil {
 		value, err := agentFinalMessageFromProto(req.GetFinalMessage())

--- a/internal/store/instances.go
+++ b/internal/store/instances.go
@@ -494,3 +494,50 @@ func (s *Store) touchInstanceActivity(ctx context.Context, agentInstanceID uuid.
 	}
 	return nil
 }
+
+// IdleInstance is an active instance whose class sets an idle limit, and the
+// facts needed to decide whether it has passed it.
+type IdleInstance struct {
+	ID             uuid.UUID
+	LastActivityAt time.Time
+	IdleTTL        string
+}
+
+// ListIdleGCCandidates returns active instances belonging to an agent that sets
+// instance_idle_ttl.
+//
+// The comparison itself happens in Go: the TTL is a Go duration string, and
+// Postgres reads only a subset of that syntax as an interval -- "1h30m" is a
+// perfectly good Go duration and not an interval at all. Only instances whose
+// class opted in are read, so the set is small by construction.
+func (s *Store) ListIdleGCCandidates(ctx context.Context, limit int) ([]IdleInstance, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT ai.id, ai.last_activity_at, a.instance_idle_ttl
+		   FROM agent_instances ai
+		   JOIN agents a ON a.id = ai.agent_id
+		  WHERE ai.state = $1
+		    AND a.instance_idle_ttl IS NOT NULL
+		    AND a.instance_idle_ttl <> ''
+		  ORDER BY ai.last_activity_at
+		  LIMIT $2`,
+		AgentInstanceStateActive,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	candidates := make([]IdleInstance, 0)
+	for rows.Next() {
+		var candidate IdleInstance
+		if err := rows.Scan(&candidate.ID, &candidate.LastActivityAt, &candidate.IdleTTL); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates, rows.Err()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message, created_at, updated_at`
+	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message, instance_idle_ttl, created_at, updated_at`
 	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
 	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, hook_id, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, organization_id, image_pull_secret_id, agent_id, mcp_id, hook_id, environment_id, created_at, updated_at`
@@ -79,6 +79,7 @@ func encodeCapabilities(capabilities []string) ([]byte, error) {
 func scanAgent(row pgx.Row) (Agent, error) {
 	var agent Agent
 	var idleTimeout pgtype.Text
+	var instanceIdleTTL pgtype.Text
 	var capabilities []byte
 	var environmentID pgtype.UUID
 	if err := row.Scan(
@@ -102,12 +103,14 @@ func scanAgent(row pgx.Row) (Agent, error) {
 		&environmentID,
 		&agent.DefaultThread,
 		&agent.FinalMessage,
+		&instanceIdleTTL,
 		&agent.Meta.CreatedAt,
 		&agent.Meta.UpdatedAt,
 	); err != nil {
 		return Agent{}, err
 	}
 	agent.IdleTimeout = stringPtrFromPg(idleTimeout)
+	agent.InstanceIdleTTL = stringPtrFromPg(instanceIdleTTL)
 	agent.EnvironmentID = uuidPtrFromPg(environmentID)
 	decodedCapabilities, err := decodeCapabilities(capabilities)
 	if err != nil {
@@ -378,8 +381,8 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		return Agent{}, err
 	}
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+		fmt.Sprintf(`INSERT INTO agents (organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message, instance_idle_ttl)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 		 RETURNING %s`, agentColumns),
 		organizationID,
 		input.Name,
@@ -400,6 +403,7 @@ func (s *Store) CreateAgent(ctx context.Context, organizationID uuid.UUID, input
 		input.EnvironmentID,
 		input.DefaultThread,
 		input.FinalMessage,
+		input.InstanceIdleTTL,
 	)
 	agent, err := scanAgent(row)
 	if err != nil {
@@ -482,6 +486,9 @@ func (s *Store) UpdateAgent(ctx context.Context, id uuid.UUID, update AgentUpdat
 	}
 	if update.FinalMessage != nil {
 		builder.add("final_message", *update.FinalMessage)
+	}
+	if update.InstanceIdleTTL != nil {
+		builder.add("instance_idle_ttl", *update.InstanceIdleTTL)
 	}
 
 	if builder.empty() {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -20,20 +20,21 @@ type ComputeResources struct {
 }
 
 type Agent struct {
-	Meta           EntityMeta
-	OrganizationID uuid.UUID
-	Name           string
-	Nickname       string
-	Role           string
-	Model          uuid.UUID
-	Description    string
-	Configuration  string
-	Image          string
-	InitImage      string
-	IdleTimeout    *string
-	Capabilities   []string
-	Availability   AgentAvailability
-	Resources      ComputeResources
+	Meta            EntityMeta
+	OrganizationID  uuid.UUID
+	Name            string
+	Nickname        string
+	Role            string
+	Model           uuid.UUID
+	Description     string
+	Configuration   string
+	Image           string
+	InitImage       string
+	IdleTimeout     *string
+	InstanceIdleTTL *string
+	Capabilities    []string
+	Availability    AgentAvailability
+	Resources       ComputeResources
 	// The environment supplying this agent's image and compute. Null on agents
 	// written before environments existed, which still carry Image and
 	// Resources of their own.
@@ -284,21 +285,22 @@ type InitScript struct {
 }
 
 type AgentInput struct {
-	Name          string
-	Nickname      string
-	Role          string
-	Model         uuid.UUID
-	Description   string
-	Configuration string
-	Image         string
-	InitImage     string
-	IdleTimeout   *string
-	Capabilities  []string
-	Availability  AgentAvailability
-	Resources     ComputeResources
-	EnvironmentID *uuid.UUID
-	DefaultThread AgentDefaultThread
-	FinalMessage  AgentFinalMessage
+	Name            string
+	Nickname        string
+	Role            string
+	Model           uuid.UUID
+	Description     string
+	Configuration   string
+	Image           string
+	InitImage       string
+	IdleTimeout     *string
+	Capabilities    []string
+	Availability    AgentAvailability
+	Resources       ComputeResources
+	EnvironmentID   *uuid.UUID
+	DefaultThread   AgentDefaultThread
+	FinalMessage    AgentFinalMessage
+	InstanceIdleTTL *string
 }
 
 type AgentUpdate struct {
@@ -320,6 +322,7 @@ type AgentUpdate struct {
 	ClearEnvironmentID bool
 	DefaultThread      *AgentDefaultThread
 	FinalMessage       *AgentFinalMessage
+	InstanceIdleTTL    *string
 }
 
 type VolumeInput struct {

--- a/migrations/0020_agent_instance_idle_ttl.sql
+++ b/migrations/0020_agent_instance_idle_ttl.sql
@@ -1,0 +1,17 @@
+-- How long an instance may sit idle before the platform pauses it.
+--
+-- On the class, not the instance: idleness is measured per instance, but how
+-- much of it is tolerable describes the kind of agent. A long-lived assistant
+-- and a one-shot worker want different answers, and every instance of one
+-- agent wants the same one.
+--
+-- Nullable, and null means never. An agent that predates this column keeps
+-- instances until something else stops them, which is what it did yesterday.
+ALTER TABLE agents
+    ADD COLUMN instance_idle_ttl TEXT;
+
+-- The GC sweeps active instances by last_activity_at. Without this it reads
+-- every active instance in the deployment on every tick.
+CREATE INDEX IF NOT EXISTS agent_instances_active_last_activity_idx
+    ON agent_instances (last_activity_at)
+    WHERE state = 'active';


### PR DESCRIPTION
The last unimplemented item in [`2026-07-14-agent-instances-and-inboxes.md`](https://github.com/agynio/architecture/blob/main/changes/2026-07-14-agent-instances-and-inboxes.md):

> Instance idle GC (background loop that transitions `active → paused` past `instance_idle_ttl` with `pause_reason=idle_ttl_exceeded`) is not implemented.

- **`0020_agent_instance_idle_ttl.sql`** — the column on `agents`, plus a partial index on `agent_instances (last_activity_at) WHERE state = 'active'` so the sweep does not read every active instance in the deployment each tick.
- **`ListIdleGCCandidates`** — active instances whose class opted in, oldest first.
- **`RunInstanceIdleGC`** — a ticker started from `main` before `Serve`, so a service that never receives a request still reclaims what earlier runs left behind. `INSTANCE_IDLE_GC_INTERVAL` overrides the one-minute default.

**Paused, not terminated.** The instance keeps its thread, default thread and inbox, so `ResumeInstance` picks up whatever arrived. What the sweep reclaims is the workload behind it, which the Orchestrator stops once the instance is no longer active.

**The comparison runs in Go, not SQL.** The column holds a Go duration string and Postgres reads only a subset of that syntax as an interval — `1h30m` is a perfectly good duration and not an interval at all. A test pins that case.

Three tests cover the decision without a database: past/not-past the limit, an unreadable TTL left alone rather than swept on a guess, and one instance failing to pause not taking the rest of the batch with it.

**Depends on [api#169](https://github.com/agynio/api/pull/169)** for the RPC field — until that merges the column is settable only in the database. I'll push the `CreateAgent`/`UpdateAgent` wiring here once it lands.