### PR TITLE
fix: store the default thread an instance was created with

### DIFF
--- a/internal/server/default_thread_test.go
+++ b/internal/server/default_thread_test.go
@@ -133,3 +133,28 @@ func TestClassPolicyRoundTrips(t *testing.T) {
 		}
 	}
 }
+
+// The resolved thread was a parameter of createInstanceWithIdentity and never
+// reached the row it builds, so every instance was written with a null
+// default_thread_id whatever the class policy decided or the caller asked for.
+func TestAgentInstanceInputCarriesTheDefaultThread(t *testing.T) {
+	threadID := uuid.New()
+	agent := store.Agent{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Nickname:       "helper",
+	}
+
+	input := agentInstanceInput(agent, nil, "a1b2c3d4", &threadID)
+	if input.DefaultThreadID == nil {
+		t.Fatal("the resolved default thread was dropped")
+	}
+	if *input.DefaultThreadID != threadID {
+		t.Fatalf("expected %s, got %s", threadID, *input.DefaultThreadID)
+	}
+
+	// And nil stays nil: an instance whose class infers nothing has none.
+	if got := agentInstanceInput(agent, nil, "a1b2c3d4", nil); got.DefaultThreadID != nil {
+		t.Fatalf("expected no default thread, got %v", got.DefaultThreadID)
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -86,6 +86,23 @@ func resolveDefaultThread(agent store.Agent, req *agentsv1.CreateInstanceRequest
 	return &id, nil
 }
 
+// agentInstanceInput assembles the row an instance is created from.
+//
+// Extracted so the resolved default thread cannot go missing again: it was a
+// parameter of the caller and simply never reached this struct, so every
+// instance was written with a null default_thread_id no matter what the class
+// policy resolved or the caller asked for.
+func agentInstanceInput(agent store.Agent, label *string, suffix string, defaultThreadID *uuid.UUID) store.AgentInstanceInput {
+	return store.AgentInstanceInput{
+		AgentID:         agent.Meta.ID,
+		OrganizationID:  agent.OrganizationID,
+		Label:           label,
+		Suffix:          suffix,
+		Nickname:        agent.Nickname,
+		DefaultThreadID: defaultThreadID,
+	}
+}
+
 func (s *Server) createInstanceWithIdentity(ctx context.Context, agent store.Agent, label *string, defaultThreadID *uuid.UUID) (store.AgentInstance, error) {
 	attempts := 1
 	if label == nil {
@@ -97,13 +114,7 @@ func (s *Server) createInstanceWithIdentity(ctx context.Context, agent store.Age
 		if label != nil {
 			suffix = *label
 		}
-		instance, err := s.store.CreateAgentInstance(ctx, store.AgentInstanceInput{
-			AgentID:        agent.Meta.ID,
-			OrganizationID: agent.OrganizationID,
-			Label:          label,
-			Suffix:         suffix,
-			Nickname:       agent.Nickname,
-		})
+		instance, err := s.store.CreateAgentInstance(ctx, agentInstanceInput(agent, label, suffix, defaultThreadID))
 		if err != nil {
 			if _, ok := err.(*store.AlreadyExistsError); ok && label == nil {
 				lastErr = err


### PR DESCRIPTION
**`default_thread` has never worked for any instance**, which is the whole point of `architecture/changes/2026-08-01-agent-default-thread.md`.

Everything around it is correct: `resolveDefaultThread` applies the class policy, `CreateInstance` validates the id, the column exists, and the `INSERT` names it. But `createInstanceWithIdentity` takes `defaultThreadID` as a parameter and never puts it in the struct:

```go
instance, err := s.store.CreateAgentInstance(ctx, store.AgentInstanceInput{
    AgentID:        agent.Meta.ID,
    OrganizationID: agent.OrganizationID,
    Label:          label,
    Suffix:         suffix,
    Nickname:       agent.Nickname,
})   // defaultThreadID dropped
```

So every instance was written with a null `default_thread_id`, and an agent could never send without naming a thread.

**Found by running it, not reading it.** Against a platform VM:

```
$ agyn agents instantiate @agent --label dtest --default-thread localtest-thread
a90e325a-…  @agent#dtest
$ psql -c "select suffix, default_thread_id from agent_instances where …"
 dtest |
```

An invalid value *is* rejected (`default_thread_id: invalid UUID length: 10`), which proved resolution and validation were fine and narrowed it to persistence.

The row is now assembled by a named function with a test that fails without the fix. Inline, a missing field looks like every other line.

Shipped in 0.7.7.