### PR TITLE
chore: remove the ArgoCD sync dance

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -5,30 +5,6 @@ vars:
   DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
-  disable_argocd_sync: |-
-    if kubectl get application agents -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for agents..."
-      kubectl patch application agents -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":null}}}'
-      echo "ArgoCD auto-sync disabled."
-    else
-      echo "WARNING: ArgoCD Application 'agents' not found in argocd namespace."
-    fi
-  restore_argocd_sync: &restore_argocd_sync |-
-    if [ -n "${CI:-}" ]; then
-      echo "Skipping ArgoCD auto-sync restore in CI."
-      exit 0
-    fi
-    if kubectl get application agents -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for agents..."
-      kubectl patch application agents -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-      echo "ArgoCD auto-sync restored."
-    else
-      echo "WARNING: ArgoCD Application 'agents' not found in argocd namespace."
-    fi
   patch_deployment: |-
     echo "Patching agents deployment for DevSpace..."
     kubectl patch deployment agents -n ${AGENTS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
@@ -95,7 +71,6 @@ pipelines:
         short: w
         description: "Keep DevSpace running and stream logs"
     run: |-
-      disable_argocd_sync
       patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace agents
@@ -119,13 +94,6 @@ pipelines:
       fi
 
 hooks:
-  - name: restore-argocd-auto-sync
-    events:
-      - after:dev:agents
-    command: bash
-    args:
-      - -c
-      - *restore_argocd_sync
 
 dev:
   agents:

--- a/internal/server/default_thread_test.go
+++ b/internal/server/default_thread_test.go
@@ -133,3 +133,28 @@ func TestClassPolicyRoundTrips(t *testing.T) {
 		}
 	}
 }
+
+// The resolved thread was a parameter of createInstanceWithIdentity and never
+// reached the row it builds, so every instance was written with a null
+// default_thread_id whatever the class policy decided or the caller asked for.
+func TestAgentInstanceInputCarriesTheDefaultThread(t *testing.T) {
+	threadID := uuid.New()
+	agent := store.Agent{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		OrganizationID: uuid.New(),
+		Nickname:       "helper",
+	}
+
+	input := agentInstanceInput(agent, nil, "a1b2c3d4", &threadID)
+	if input.DefaultThreadID == nil {
+		t.Fatal("the resolved default thread was dropped")
+	}
+	if *input.DefaultThreadID != threadID {
+		t.Fatalf("expected %s, got %s", threadID, *input.DefaultThreadID)
+	}
+
+	// And nil stays nil: an instance whose class infers nothing has none.
+	if got := agentInstanceInput(agent, nil, "a1b2c3d4", nil); got.DefaultThreadID != nil {
+		t.Fatalf("expected no default thread, got %v", got.DefaultThreadID)
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -86,6 +86,23 @@ func resolveDefaultThread(agent store.Agent, req *agentsv1.CreateInstanceRequest
 	return &id, nil
 }
 
+// agentInstanceInput assembles the row an instance is created from.
+//
+// Extracted so the resolved default thread cannot go missing again: it was a
+// parameter of the caller and simply never reached this struct, so every
+// instance was written with a null default_thread_id no matter what the class
+// policy resolved or the caller asked for.
+func agentInstanceInput(agent store.Agent, label *string, suffix string, defaultThreadID *uuid.UUID) store.AgentInstanceInput {
+	return store.AgentInstanceInput{
+		AgentID:         agent.Meta.ID,
+		OrganizationID:  agent.OrganizationID,
+		Label:           label,
+		Suffix:          suffix,
+		Nickname:        agent.Nickname,
+		DefaultThreadID: defaultThreadID,
+	}
+}
+
 func (s *Server) createInstanceWithIdentity(ctx context.Context, agent store.Agent, label *string, defaultThreadID *uuid.UUID) (store.AgentInstance, error) {
 	attempts := 1
 	if label == nil {
@@ -97,13 +114,7 @@ func (s *Server) createInstanceWithIdentity(ctx context.Context, agent store.Age
 		if label != nil {
 			suffix = *label
 		}
-		instance, err := s.store.CreateAgentInstance(ctx, store.AgentInstanceInput{
-			AgentID:        agent.Meta.ID,
-			OrganizationID: agent.OrganizationID,
-			Label:          label,
-			Suffix:         suffix,
-			Nickname:       agent.Nickname,
-		})
+		instance, err := s.store.CreateAgentInstance(ctx, agentInstanceInput(agent, label, suffix, defaultThreadID))
 		if err != nil {
 			if _, ok := err.(*store.AlreadyExistsError); ok && label == nil {
 				lastErr = err


### PR DESCRIPTION
ArgoCD went away with bootstrap. Disabling its auto-sync before a source deploy and restoring it after has had nothing to disable or restore since the platform moved to the VM — every run printed `WARNING: ArgoCD Application not found in argocd namespace` and carried on.

Removes the `disable_argocd_sync` / `restore_argocd_sync` functions, their call sites, the `restore-argocd` pipeline and the `after:dev` hook.

Part of removing the E2E workflow’s build-time source patches: three of them existed only to inject a "skip the ArgoCD restore in CI" branch into this file.