### PR TITLE
Let the platform pause an instance it cannot run

### DIFF
--- a/charts/agents/templates/authorization-policy.yaml
+++ b/charts/agents/templates/authorization-policy.yaml
@@ -48,3 +48,35 @@ spec:
               - POST
             paths:
               - /agynio.api.agents.v1.AgentsService/UpdateSandboxRuntimeState
+---
+# PauseInstance is reachable both ways: the Orchestrator pauses on the
+# platform's behalf with no identity, and a user pauses deliberately through the
+# Gateway, which attaches theirs and is then held to can_manage in the service.
+# So this narrows who may reach the RPC at all, rather than standing in for that
+# check -- without it any workload in the mesh could pause any instance by
+# simply omitting an identity.
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Release.Name }}-pause-instance
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  action: DENY
+  rules:
+    - from:
+        - source:
+            notPrincipals:
+              - "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator"
+              - "cluster.local/ns/{{ .Release.Namespace }}/sa/gateway"
+      to:
+        - operation:
+            methods:
+              - POST
+            paths:
+              - /agynio.api.agents.v1.AgentsService/PauseInstance

--- a/internal/server/authorization_policy_test.go
+++ b/internal/server/authorization_policy_test.go
@@ -6,21 +6,49 @@ import (
 	"testing"
 )
 
-func TestAuthorizationPolicyRestrictsSandboxRuntimeStateUpdate(t *testing.T) {
+// policyFor returns the one document in the chart's policy file that names the
+// given RPC. The file holds several, and asserting against the whole of it only
+// worked while every policy in it happened to agree: adding one that does allow
+// the Gateway made a check of the file read as a check of the wrong policy.
+func policyFor(t *testing.T, method string) string {
+	t.Helper()
 	policy, err := os.ReadFile("../../charts/agents/templates/authorization-policy.yaml")
 	if err != nil {
 		t.Fatalf("read authorization policy: %v", err)
 	}
-	content := string(policy)
+	for _, document := range strings.Split(string(policy), "\n---\n") {
+		if strings.Contains(document, method) {
+			return document
+		}
+	}
+	t.Fatalf("no authorization policy names %s", method)
+	return ""
+}
+
+func TestAuthorizationPolicyRestrictsSandboxRuntimeStateUpdate(t *testing.T) {
+	content := policyFor(t, "/agynio.api.agents.v1.AgentsService/UpdateSandboxRuntimeState")
 
 	assertContains(t, content, "{{ .Release.Name }}-update-sandbox-runtime-state")
-	assertContains(t, content, "/agynio.api.agents.v1.AgentsService/UpdateSandboxRuntimeState")
 	assertContains(t, content, "notPrincipals:")
 	assertContains(t, content, "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator")
 
 	if strings.Contains(content, "cluster.local/ns/{{ .Release.Namespace }}/sa/gateway") {
 		t.Fatalf("sandbox runtime state update policy must not allow the gateway user path")
 	}
+}
+
+// PauseInstance serves an unidentified caller, which the service can only read
+// as the platform acting. Nothing in the service distinguishes the Orchestrator
+// from any other workload in the mesh, so this policy is what makes that true;
+// the Gateway is named because a user's deliberate pause arrives through it and
+// is held to can_manage in the service.
+func TestAuthorizationPolicyRestrictsPauseInstance(t *testing.T) {
+	content := policyFor(t, "/agynio.api.agents.v1.AgentsService/PauseInstance")
+
+	assertContains(t, content, "{{ .Release.Name }}-pause-instance")
+	assertContains(t, content, "notPrincipals:")
+	assertContains(t, content, "cluster.local/ns/{{ .Release.Namespace }}/sa/agents-orchestrator")
+	assertContains(t, content, "cluster.local/ns/{{ .Release.Namespace }}/sa/gateway")
 }
 
 func assertContains(t *testing.T, content string, expected string) {

--- a/internal/server/instance_pause_authorization_test.go
+++ b/internal/server/instance_pause_authorization_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The Orchestrator pauses instances the platform can no longer run -- the
+// runner is gone, the volume is lost, start retries are spent -- and reaches
+// Agents over the mesh with no identity of its own. Held to can_manage it was
+// refused every one of those, because the identity it did present was the
+// instance's, and an instance is not an owner of its own class.
+func TestPauseServesTheInternalCallerWithoutAnIdentity(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.requireManageInstanceUnlessInternal(t.Context(), uuid.New()); err != nil {
+		t.Fatalf("expected the internal caller to be served, got %v", err)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization checks, got %d", len(authz.checks))
+	}
+}
+
+// Presenting an identity makes the caller a principal, and a deliberate pause
+// is still an owner's to make.
+func TestPauseRefusesAnIdentityWithoutCanManage(t *testing.T) {
+	instanceID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{}}
+	server := &Server{authz: authz}
+
+	err := server.requireManageInstanceUnlessInternal(identityContext(identityID), instanceID)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected an identified caller without can_manage to be refused, got %v", err)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{{
+		User:     identityPrefix + identityID.String(),
+		Relation: "can_manage",
+		Object:   agentInstancePrefix + instanceID.String(),
+	}})
+}
+
+func TestPauseServesAnIdentityWithCanManage(t *testing.T) {
+	instanceID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.requireManageInstanceUnlessInternal(identityContext(identityID), instanceID); err != nil {
+		t.Fatalf("expected an owner to be served, got %v", err)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{{
+		User:     identityPrefix + identityID.String(),
+		Relation: "can_manage",
+		Object:   agentInstancePrefix + instanceID.String(),
+	}})
+}
+
+// A malformed identity is a broken caller, not an internal one: falling through
+// to the unidentified path would turn a typo into an authorization bypass.
+func TestPauseRejectsAMalformedIdentity(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	err := server.requireManageInstanceUnlessInternal(malformedIdentityContext(), uuid.New())
+	if err == nil || !strings.Contains(err.Error(), "identity_id") {
+		t.Fatalf("expected a malformed identity to be rejected, got %v", err)
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -287,6 +287,14 @@ func (s *Server) ListInstances(ctx context.Context, req *agentsv1.ListInstancesR
 	return &agentsv1.ListInstancesResponse{Instances: instances, NextPageToken: nextToken}, nil
 }
 
+// PauseInstance stops an instance from spawning workloads. Two callers reach
+// it, and only one of them is a principal: a user, app or agent pausing an
+// instance deliberately holds can_manage, while the Orchestrator pauses on the
+// platform's behalf -- the runner was deprovisioned, the volume is gone, start
+// retries are spent -- and has no identity to hold anything. Requiring
+// can_manage of both left the Orchestrator unable to record any of those, since
+// an instance is not an owner of its own class. An AuthorizationPolicy narrows
+// the unidentified path to the Orchestrator.
 func (s *Server) PauseInstance(ctx context.Context, req *agentsv1.PauseInstanceRequest) (*agentsv1.PauseInstanceResponse, error) {
 	id, err := parseUUID(req.GetId())
 	if err != nil {
@@ -295,7 +303,7 @@ func (s *Server) PauseInstance(ctx context.Context, req *agentsv1.PauseInstanceR
 	if req.GetPauseReason() == "" {
 		return nil, status.Error(codes.InvalidArgument, "pause_reason must be provided")
 	}
-	if err := s.requireManageInstance(ctx, id); err != nil {
+	if err := s.requireManageInstanceUnlessInternal(ctx, id); err != nil {
 		return nil, err
 	}
 	instance, err := s.store.PauseAgentInstance(ctx, id, req.GetPauseReason())
@@ -362,6 +370,21 @@ func (s *Server) DeleteInstance(ctx context.Context, req *agentsv1.DeleteInstanc
 	}
 	s.publishInstanceUpdated(ctx, instance)
 	return &agentsv1.DeleteInstanceResponse{Instance: toProtoAgentInstance(instance)}, nil
+}
+
+// requireManageInstanceUnlessInternal authorizes a lifecycle change that the
+// platform itself makes as well as its owner. An internal caller holds no
+// identity, the same signal FanoutInboxItem and the instance reads already use;
+// anyone who presents one is a principal and is held to can_manage.
+func (s *Server) requireManageInstanceUnlessInternal(ctx context.Context, id uuid.UUID) error {
+	_, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasIdentity {
+		return nil
+	}
+	return s.requireManageInstance(ctx, id)
 }
 
 func (s *Server) requireManageInstance(ctx context.Context, id uuid.UUID) error {


### PR DESCRIPTION
The Orchestrator pauses instances the platform can no longer run — runner deprovisioned, volume lost, start retries spent — and **every one of those was refused**:

```
reconciler: pause agent instance c96fddaf-...: PermissionDenied: identity cannot manage this agent instance
```

It reached `PauseInstance` carrying the *instance's own* identity (borrowed from the runner reads around the call), and `agent_instance.can_manage` derives from the class's `can_delete` — an instance is not an owner of its own class, so the check could only deny it.

`PauseInstance` now serves an unidentified caller, the same signal `FanoutInboxItem` and `requireInstanceReadAccess` already read as the platform acting, and holds an identified one to `can_manage` — which is what [the spec](https://github.com/agynio/architecture/blob/main/architecture/agent-instances.md) means by "explicit PauseInstance by an authorized caller (`manual`)". An AuthorizationPolicy narrows who may reach the RPC at all to the Orchestrator and the Gateway.

Paired with agynio/agents-orchestrator#… which stops sending the instance identity.

The policy test asserted against the whole chart file, which only worked while every policy in it agreed about the Gateway; it now reads the document for the RPC it is about.