### PR TITLE
Name the sender on inbox items

### DIFF
--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -327,6 +327,10 @@ func (noopIdentityWriter) RemoveNickname(context.Context, *identityv1.RemoveNick
 	return &identityv1.RemoveNicknameResponse{}, nil
 }
 
+func (noopIdentityWriter) BatchGetNicknames(context.Context, *identityv1.BatchGetNicknamesRequest, ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+	return &identityv1.BatchGetNicknamesResponse{}, nil
+}
+
 type noopNotificationsClient struct{}
 
 func (noopNotificationsClient) Publish(context.Context, *notificationsv1.PublishRequest, ...grpc.CallOption) (*notificationsv1.PublishResponse, error) {

--- a/internal/server/identity.go
+++ b/internal/server/identity.go
@@ -11,6 +11,7 @@ type IdentityWriter interface {
 	RegisterIdentity(ctx context.Context, req *identityv1.RegisterIdentityRequest, opts ...grpc.CallOption) (*identityv1.RegisterIdentityResponse, error)
 	SetNickname(ctx context.Context, req *identityv1.SetNicknameRequest, opts ...grpc.CallOption) (*identityv1.SetNicknameResponse, error)
 	RemoveNickname(ctx context.Context, req *identityv1.RemoveNicknameRequest, opts ...grpc.CallOption) (*identityv1.RemoveNicknameResponse, error)
+	BatchGetNicknames(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error)
 }
 
 type identityWriter struct {
@@ -34,4 +35,8 @@ func (w *identityWriter) SetNickname(ctx context.Context, req *identityv1.SetNic
 
 func (w *identityWriter) RemoveNickname(ctx context.Context, req *identityv1.RemoveNicknameRequest, opts ...grpc.CallOption) (*identityv1.RemoveNicknameResponse, error) {
 	return w.client.RemoveNickname(ctx, req, opts...)
+}
+
+func (w *identityWriter) BatchGetNicknames(ctx context.Context, req *identityv1.BatchGetNicknamesRequest, opts ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+	return w.client.BatchGetNicknames(ctx, req, opts...)
 }

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log"
 	"regexp"
 	"strings"
 
@@ -470,7 +471,75 @@ func (s *Server) GetUnackedInboxItems(ctx context.Context, req *agentsv1.GetUnac
 		return nil, toStatusError(err)
 	}
 	items, nextToken := mapInboxListResult(result.Items, result.NextCursor, toProtoInboxItem)
+	s.attachSenderHandles(ctx, instanceID, items)
 	return &agentsv1.GetUnackedInboxItemsResponse{Items: items, NextPageToken: nextToken}, nil
+}
+
+// attachSenderHandles names each sender, because the reader is an agent
+// workload and the Identity service is not reachable from one. A failure leaves
+// the handles empty rather than failing the read: the sender id still stands.
+func (s *Server) attachSenderHandles(ctx context.Context, instanceID uuid.UUID, items []*agentsv1.InboxItem) {
+	if len(items) == 0 {
+		return
+	}
+	instance, err := s.store.GetAgentInstance(ctx, instanceID)
+	if err != nil {
+		log.Printf("agents: read instance %s for sender handles: %v", instanceID, err)
+		return
+	}
+	entries, err := s.senderHandles(ctx, instance.OrganizationID.String(), items)
+	if err != nil {
+		log.Printf("agents: resolve sender handles for instance %s: %v", instanceID, err)
+		return
+	}
+	s.applySenderHandles(items, entries)
+}
+
+func (s *Server) senderHandles(ctx context.Context, organizationID string, items []*agentsv1.InboxItem) ([]*identityv1.NicknameEntry, error) {
+	senderIDs := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		senderID := item.GetSenderId()
+		if senderID == "" {
+			continue
+		}
+		if _, ok := seen[senderID]; ok {
+			continue
+		}
+		seen[senderID] = struct{}{}
+		senderIDs = append(senderIDs, senderID)
+	}
+	if len(senderIDs) == 0 {
+		return nil, nil
+	}
+	response, err := s.identity.BatchGetNicknames(ctx, &identityv1.BatchGetNicknamesRequest{
+		OrganizationId: organizationID,
+		IdentityIds:    senderIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response.GetEntries(), nil
+}
+
+func (s *Server) applySenderHandles(items []*agentsv1.InboxItem, entries []*identityv1.NicknameEntry) {
+	handles := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		handle := entry.GetNickname()
+		if handle == "" {
+			continue
+		}
+		if suffix := entry.GetInstanceSuffix(); suffix != "" {
+			handle += "#" + suffix
+		}
+		handles[entry.GetIdentityId()] = handle
+	}
+	for _, item := range items {
+		if handle, ok := handles[item.GetSenderId()]; ok {
+			value := handle
+			item.SenderHandle = &value
+		}
+	}
 }
 
 func (s *Server) AckInboxItems(ctx context.Context, req *agentsv1.AckInboxItemsRequest) (*agentsv1.AckInboxItemsResponse, error) {

--- a/internal/server/sender_handle_test.go
+++ b/internal/server/sender_handle_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	identityv1 "github.com/agynio/agents/.gen/go/agynio/api/identity/v1"
+	"google.golang.org/grpc"
+)
+
+type nicknameIdentityWriter struct {
+	noopIdentityWriter
+	entries []*identityv1.NicknameEntry
+	err     error
+	request *identityv1.BatchGetNicknamesRequest
+}
+
+func (w *nicknameIdentityWriter) BatchGetNicknames(_ context.Context, req *identityv1.BatchGetNicknamesRequest, _ ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+	w.request = req
+	if w.err != nil {
+		return nil, w.err
+	}
+	return &identityv1.BatchGetNicknamesResponse{Entries: w.entries}, nil
+}
+
+func TestSenderHandlesAreAttached(t *testing.T) {
+	suffix := "a1b2"
+	identity := &nicknameIdentityWriter{entries: []*identityv1.NicknameEntry{
+		{IdentityId: "sender-1", Nickname: "rowan"},
+		{IdentityId: "sender-2", Nickname: "casey", InstanceSuffix: &suffix},
+	}}
+	server := &Server{identity: identity}
+	items := []*agentsv1.InboxItem{
+		{SenderId: "sender-1"},
+		{SenderId: "sender-2"},
+		{SenderId: "sender-3"},
+	}
+
+	server.applySenderHandles(items, identity.entries)
+
+	if got := items[0].GetSenderHandle(); got != "rowan" {
+		t.Fatalf("expected rowan, got %q", got)
+	}
+	if got := items[1].GetSenderHandle(); got != "casey#a1b2" {
+		t.Fatalf("expected casey#a1b2, got %q", got)
+	}
+	if items[2].SenderHandle != nil {
+		t.Fatalf("expected no handle for an unknown sender, got %q", items[2].GetSenderHandle())
+	}
+}
+
+func TestSenderHandlesSkipEmptyNicknames(t *testing.T) {
+	server := &Server{identity: &nicknameIdentityWriter{}}
+	items := []*agentsv1.InboxItem{{SenderId: "sender-1"}}
+
+	server.applySenderHandles(items, []*identityv1.NicknameEntry{{IdentityId: "sender-1", Nickname: ""}})
+
+	if items[0].SenderHandle != nil {
+		t.Fatalf("expected no handle, got %q", items[0].GetSenderHandle())
+	}
+}
+
+func TestSenderHandleLookupFailureLeavesItemsIntact(t *testing.T) {
+	identity := &nicknameIdentityWriter{err: errors.New("identity is down")}
+	server := &Server{identity: identity}
+	items := []*agentsv1.InboxItem{{SenderId: "sender-1", Body: "hello"}}
+
+	handles, err := server.senderHandles(context.Background(), "org-1", items)
+	if err == nil {
+		t.Fatal("expected the lookup error to be reported")
+	}
+	if handles != nil {
+		t.Fatalf("expected no entries, got %v", handles)
+	}
+	if items[0].GetBody() != "hello" {
+		t.Fatal("expected the item to be untouched")
+	}
+}
+
+func TestSenderHandlesRequestUniqueSenders(t *testing.T) {
+	identity := &nicknameIdentityWriter{}
+	server := &Server{identity: identity}
+	items := []*agentsv1.InboxItem{
+		{SenderId: "sender-1"},
+		{SenderId: "sender-1"},
+		{SenderId: ""},
+		{SenderId: "sender-2"},
+	}
+
+	if _, err := server.senderHandles(context.Background(), "org-1", items); err != nil {
+		t.Fatalf("sender handles: %v", err)
+	}
+	if got := identity.request.GetIdentityIds(); len(got) != 2 {
+		t.Fatalf("expected two unique senders, got %v", got)
+	}
+}


### PR DESCRIPTION
Fills `InboxItem.sender_handle` (agynio/api#170) from `Identity.BatchGetNicknames` when serving `GetUnackedInboxItems`.

agynd prefixes each item with a header naming its source, and the spec calls for `from: @sender-handle`. An agent workload reaches the platform through the Gateway, and [identity.md](https://github.com/agynio/architecture/blob/main/architecture/identity.md) keeps the Identity service internal — nicknames reach external clients through the owner service — so agynd could only show the model a raw identity id.

A lookup failure leaves the handles empty rather than failing the read; the sender id still stands.