### PR TITLE
Resolve sender handles as this service

### DIFF
--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -487,12 +487,9 @@ func (s *Server) attachSenderHandles(ctx context.Context, instanceID uuid.UUID, 
 		log.Printf("agents: read instance %s for sender handles: %v", instanceID, err)
 		return
 	}
-	identityCtx, err := identityOutgoingContext(ctx)
-	if err != nil {
-		log.Printf("agents: forward identity for sender handles: %v", err)
-		return
-	}
-	entries, err := s.senderHandles(identityCtx, instance.OrganizationID.String(), items)
+	// Resolved as this service, not as the caller: can_view_threads is
+	// owner-or-cluster-admin, which no agent instance holds.
+	entries, err := s.senderHandles(ctx, instance.OrganizationID.String(), items)
 	if err != nil {
 		log.Printf("agents: resolve sender handles for instance %s: %v", instanceID, err)
 		return

--- a/internal/server/sender_handle_test.go
+++ b/internal/server/sender_handle_test.go
@@ -101,24 +101,19 @@ func TestSenderHandlesRequestUniqueSenders(t *testing.T) {
 	}
 }
 
-func TestSenderHandlesForwardTheCallerIdentity(t *testing.T) {
+// Resolved as this service: can_view_threads is owner-or-cluster-admin, which
+// no agent instance holds, so forwarding the caller made every handle empty.
+func TestSenderHandlesDoNotImpersonateTheCaller(t *testing.T) {
 	identity := &nicknameIdentityWriter{}
 	server := &Server{identity: identity}
-	callerID := uuid.New()
 
-	identityCtx, err := identityOutgoingContext(identityContext(callerID))
-	if err != nil {
-		t.Fatalf("identity context: %v", err)
-	}
-	if _, err := server.senderHandles(identityCtx, "org-1", []*agentsv1.InboxItem{{SenderId: "sender-1"}}); err != nil {
+	if _, err := server.senderHandles(identityContext(uuid.New()), "org-1", []*agentsv1.InboxItem{{SenderId: "sender-1"}}); err != nil {
 		t.Fatalf("sender handles: %v", err)
 	}
 
-	md, ok := metadata.FromOutgoingContext(identity.ctx)
-	if !ok {
-		t.Fatal("expected outgoing metadata on the lookup")
-	}
-	if got := md.Get("x-identity-id"); len(got) != 1 || got[0] != callerID.String() {
-		t.Fatalf("expected the caller identity to be forwarded, got %v", got)
+	if md, ok := metadata.FromOutgoingContext(identity.ctx); ok {
+		if got := md.Get("x-identity-id"); len(got) != 0 {
+			t.Fatalf("expected no caller identity on the lookup, got %v", got)
+		}
 	}
 }


### PR DESCRIPTION
Forwarding the caller was the wrong fix: `can_view_threads` is `owner or admin from cluster` and an agent instance is a member, so the lookup was refused with PermissionDenied instead of Unauthenticated. Agents resolves as the owner service now — needs agynio/identity#16.