### PR TITLE
Forward the caller to the nickname lookup

### DIFF
--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -487,9 +487,12 @@ func (s *Server) attachSenderHandles(ctx context.Context, instanceID uuid.UUID, 
 		log.Printf("agents: read instance %s for sender handles: %v", instanceID, err)
 		return
 	}
-	// Resolved as this service, not as the caller: can_view_threads is
-	// owner-or-cluster-admin, which no agent instance holds.
-	entries, err := s.senderHandles(ctx, instance.OrganizationID.String(), items)
+	identityCtx, err := identityOutgoingContext(ctx)
+	if err != nil {
+		log.Printf("agents: forward identity for sender handles: %v", err)
+		return
+	}
+	entries, err := s.senderHandles(identityCtx, instance.OrganizationID.String(), items)
 	if err != nil {
 		log.Printf("agents: resolve sender handles for instance %s: %v", instanceID, err)
 		return

--- a/internal/server/sender_handle_test.go
+++ b/internal/server/sender_handle_test.go
@@ -101,19 +101,27 @@ func TestSenderHandlesRequestUniqueSenders(t *testing.T) {
 	}
 }
 
-// Resolved as this service: can_view_threads is owner-or-cluster-admin, which
-// no agent instance holds, so forwarding the caller made every handle empty.
-func TestSenderHandlesDoNotImpersonateTheCaller(t *testing.T) {
+// The lookup is gated on organization membership, which the instance holds, so
+// the caller has to reach Identity: gRPC does not carry incoming metadata onto
+// an outgoing call, and without this every handle came back empty.
+func TestSenderHandlesForwardTheCallerIdentity(t *testing.T) {
 	identity := &nicknameIdentityWriter{}
 	server := &Server{identity: identity}
+	callerID := uuid.New()
 
-	if _, err := server.senderHandles(identityContext(uuid.New()), "org-1", []*agentsv1.InboxItem{{SenderId: "sender-1"}}); err != nil {
+	identityCtx, err := identityOutgoingContext(identityContext(callerID))
+	if err != nil {
+		t.Fatalf("identity context: %v", err)
+	}
+	if _, err := server.senderHandles(identityCtx, "org-1", []*agentsv1.InboxItem{{SenderId: "sender-1"}}); err != nil {
 		t.Fatalf("sender handles: %v", err)
 	}
 
-	if md, ok := metadata.FromOutgoingContext(identity.ctx); ok {
-		if got := md.Get("x-identity-id"); len(got) != 0 {
-			t.Fatalf("expected no caller identity on the lookup, got %v", got)
-		}
+	md, ok := metadata.FromOutgoingContext(identity.ctx)
+	if !ok {
+		t.Fatal("expected outgoing metadata on the lookup")
+	}
+	if got := md.Get("x-identity-id"); len(got) != 1 || got[0] != callerID.String() {
+		t.Fatalf("expected the caller identity to be forwarded, got %v", got)
 	}
 }


### PR DESCRIPTION
agynio/identity#17 gates `BatchGetNicknames` on organization membership, which an agent instance holds. So the caller must reach Identity — #81 removed the forwarding while the gate was still owner-only, and without it the lookup arrives unauthenticated.