### PR TITLE
Authorize the environment RPCs

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -93,6 +93,25 @@ func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uui
 	return s.requireAllowed(ctx, identityID, relation, organizationPrefix+organizationID.String(), status.Errorf(codes.PermissionDenied, "identity lacks %s on organization", relation))
 }
 
+// requireEnvironmentRead authorizes reading one environment. An identified
+// caller must be a member of its organization; an internal caller holds no
+// tuples and is served, as the Orchestrator reads environments while assembling
+// workloads.
+func (s *Server) requireEnvironmentRead(ctx context.Context, environment store.Environment) error {
+	return s.requireOrganizationListAccess(ctx, environment.OrganizationID)
+}
+
+// requireEnvironmentWrite authorizes changing or deleting one environment. These
+// RPCs have no internal callers, so an identity is required rather than
+// optional.
+func (s *Server) requireEnvironmentWrite(ctx context.Context, environment store.Environment) error {
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return s.requireOrganizationMember(ctx, identityID, environment.OrganizationID)
+}
+
 // requireOwnSandboxListing authorizes listing the caller's own sandboxes.
 //
 // Membership is the ordinary route. A cluster admin is not a member of every

--- a/internal/server/environment_authorization_db_test.go
+++ b/internal/server/environment_authorization_db_test.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agents/internal/db"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Get, Update and Delete name an environment by id alone and resolve its
+// organization from the record, so the refusal cannot be observed without one.
+// These run against AGENTS_TEST_DATABASE_URL — a scratch database, emptied
+// first — and are skipped when it is unset.
+func environmentAuthorizationServer(ctx context.Context, t *testing.T, authz AuthorizationWriter) (*Server, *store.Store) {
+	t.Helper()
+	url := os.Getenv("AGENTS_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("AGENTS_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if err := db.ApplyMigrations(ctx, pool); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+	backing := store.New(pool)
+	return New(backing, authz, noopIdentityWriter{}, noopNotificationsClient{}), backing
+}
+
+// An environment written straight to the store, so the setup does not depend on
+// the authorization the test is about to exercise.
+func seedEnvironment(ctx context.Context, t *testing.T, backing *store.Store, organizationID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+	runnerID := uuid.New()
+	environment, err := backing.CreateEnvironment(ctx, organizationID, store.EnvironmentInput{
+		Name:     name,
+		Image:    "ghcr.io/agynio/environment:latest",
+		RunnerID: &runnerID,
+		Flavor:   "small",
+	})
+	if err != nil {
+		t.Fatalf("seed environment: %v", err)
+	}
+	return environment.Meta.ID
+}
+
+// Holding an environment id used to be the whole permission: every one of these
+// served a caller from an unrelated organization.
+func TestEnvironmentRPCsRefuseAnotherOrganization(t *testing.T) {
+	ctx := context.Background()
+	member := uuid.New()
+	theirs := uuid.New()
+	mine := uuid.New()
+	// The caller is a member of its own organization and holds nothing on the
+	// one that owns the environment.
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + mine.String(): true,
+	}}
+	server, backing := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := seedEnvironment(ctx, t, backing, theirs, "theirs")
+	callerCtx := identityContext(member)
+
+	name := "renamed"
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"Get", func() error {
+			_, err := server.GetEnvironment(callerCtx, &agentsv1.GetEnvironmentRequest{Id: environmentID.String()})
+			return err
+		}},
+		{"Update", func() error {
+			_, err := server.UpdateEnvironment(callerCtx, &agentsv1.UpdateEnvironmentRequest{Id: environmentID.String(), Name: &name})
+			return err
+		}},
+		{"Delete", func() error {
+			_, err := server.DeleteEnvironment(callerCtx, &agentsv1.DeleteEnvironmentRequest{Id: environmentID.String()})
+			return err
+		}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := testCase.call(); err == nil {
+				t.Fatalf("%s served an environment in another organization", testCase.name)
+			}
+		})
+	}
+
+	// The record is intact: the refusals stopped before the store was written.
+	if _, err := backing.GetEnvironment(ctx, environmentID); err != nil {
+		t.Fatalf("expected the environment to survive: %v", err)
+	}
+}
+
+func TestEnvironmentRPCsServeAMember(t *testing.T) {
+	ctx := context.Background()
+	member := uuid.New()
+	organizationID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{
+		organizationPrefix + organizationID.String(): true,
+	}}
+	server, backing := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := seedEnvironment(ctx, t, backing, organizationID, "ours")
+	callerCtx := identityContext(member)
+
+	if _, err := server.GetEnvironment(callerCtx, &agentsv1.GetEnvironmentRequest{Id: environmentID.String()}); err != nil {
+		t.Fatalf("GetEnvironment refused a member: %v", err)
+	}
+	name := "renamed"
+	updated, err := server.UpdateEnvironment(callerCtx, &agentsv1.UpdateEnvironmentRequest{Id: environmentID.String(), Name: &name})
+	if err != nil {
+		t.Fatalf("UpdateEnvironment refused a member: %v", err)
+	}
+	if updated.GetEnvironment().GetName() != name {
+		t.Fatalf("expected the name to be %q, got %q", name, updated.GetEnvironment().GetName())
+	}
+	if _, err := server.DeleteEnvironment(callerCtx, &agentsv1.DeleteEnvironmentRequest{Id: environmentID.String()}); err != nil {
+		t.Fatalf("DeleteEnvironment refused a member: %v", err)
+	}
+}
+
+// The Orchestrator resolves an environment while assembling every workload,
+// over the mesh and carrying no identity.
+func TestGetEnvironmentServesAnInternalCaller(t *testing.T) {
+	ctx := context.Background()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{}}
+	server, backing := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := seedEnvironment(ctx, t, backing, uuid.New(), "ours")
+
+	if _, err := server.GetEnvironment(ctx, &agentsv1.GetEnvironmentRequest{Id: environmentID.String()}); err != nil {
+		t.Fatalf("GetEnvironment refused an internal caller: %v", err)
+	}
+}
+
+func TestUpdateEnvironmentRefusesAnInternalCaller(t *testing.T) {
+	ctx := context.Background()
+	authz := &recordingAuthorizationWriter{}
+	server, backing := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := seedEnvironment(ctx, t, backing, uuid.New(), "ours")
+
+	name := "renamed"
+	_, err := server.UpdateEnvironment(ctx, &agentsv1.UpdateEnvironmentRequest{Id: environmentID.String(), Name: &name})
+	if status.Code(err) != codes.Unauthenticated && status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected an identity-less write to be refused, got %v", err)
+	}
+}

--- a/internal/server/environment_authorization_test.go
+++ b/internal/server/environment_authorization_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The environment RPCs used to authorize nothing at all: Create took an
+// organization id and Get, Update and Delete took a bare environment id, so
+// holding an id was the permission and it reached across organizations. What
+// follows checks the decision each one now makes.
+//
+// Create refuses before touching the store, so these cases need no database. A
+// caller meant to survive the check carries an unparseable runner id and stops
+// on it — one step past the authorization and short of the store. Get, Update
+// and Delete resolve the organization from the record itself and so are covered
+// by the database-backed cases in environment_authorization_db_test.go.
+
+func TestCreateEnvironmentRefusesWithoutIdentity(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	_, err := server.CreateEnvironment(context.Background(), &agentsv1.CreateEnvironmentRequest{
+		OrganizationId: uuid.NewString(),
+		RunnerId:       uuid.NewString(),
+		Name:           "alpha",
+		Image:          "ghcr.io/agynio/environment:latest",
+	})
+	if err == nil {
+		t.Fatal("CreateEnvironment accepted a caller carrying no identity")
+	}
+}
+
+func TestCreateEnvironmentRefusesANonMember(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{}}
+	server := &Server{authz: authz}
+
+	_, err := server.CreateEnvironment(identityContext(identityID), &agentsv1.CreateEnvironmentRequest{
+		OrganizationId: organizationID.String(),
+		RunnerId:       uuid.NewString(),
+		Name:           "alpha",
+		Image:          "ghcr.io/agynio/environment:latest",
+	})
+	if err == nil {
+		t.Fatal("CreateEnvironment accepted an identity holding nothing on the organization")
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		{User: identityPrefix + identityID.String(), Relation: "member", Object: organizationPrefix + organizationID.String()},
+	})
+}
+
+func TestCreateEnvironmentChecksMembershipBeforeTheStore(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	// The runner id is unparseable, so a caller that survives the membership
+	// check stops there rather than reaching the store this server has none of.
+	_, err := server.CreateEnvironment(identityContext(identityID), &agentsv1.CreateEnvironmentRequest{
+		OrganizationId: organizationID.String(),
+		RunnerId:       "not-a-uuid",
+		Name:           "alpha",
+		Image:          "ghcr.io/agynio/environment:latest",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected the request to reach runner_id validation, got %v", err)
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		{User: identityPrefix + identityID.String(), Relation: "member", Object: organizationPrefix + organizationID.String()},
+	})
+}
+
+// An internal caller reaches the service over the mesh carrying no identity and
+// holds no tuples, so a check could only refuse it. Reads are served on those
+// terms — the Orchestrator resolves an environment while assembling every
+// workload — and writes are not, which is why Create requires an identity.
+func TestRequireEnvironmentReadServesAnInternalCaller(t *testing.T) {
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{}}
+	server := &Server{authz: authz}
+
+	if err := server.requireEnvironmentRead(context.Background(), store.Environment{OrganizationID: uuid.New()}); err != nil {
+		t.Fatalf("expected an identity-less caller to be served, got %v", err)
+	}
+	if len(authz.checks) != 0 {
+		t.Fatalf("expected no authorization check, got %d", len(authz.checks))
+	}
+}
+
+func TestRequireEnvironmentReadChecksAnIdentifiedCaller(t *testing.T) {
+	organizationID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{allowedObjects: map[string]bool{}}
+	server := &Server{authz: authz}
+
+	err := server.requireEnvironmentRead(identityContext(identityID), store.Environment{OrganizationID: organizationID})
+	if err == nil {
+		t.Fatal("expected a non-member to be refused")
+	}
+	assertChecks(t, authz.checks, []*authorizationv1.TupleKey{
+		{User: identityPrefix + identityID.String(), Relation: "member", Object: organizationPrefix + organizationID.String()},
+	})
+}
+
+func TestRequireEnvironmentWriteRefusesAnInternalCaller(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+
+	if err := server.requireEnvironmentWrite(context.Background(), store.Environment{OrganizationID: uuid.New()}); err == nil {
+		t.Fatal("expected an identity-less caller to be refused a write")
+	}
+}

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -36,6 +36,13 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
 	}
+	creatorID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrganizationMember(ctx, creatorID, organizationID); err != nil {
+		return nil, err
+	}
 	runnerID, err := parseUUID(req.GetRunnerId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
@@ -100,6 +107,9 @@ func (s *Server) GetEnvironment(ctx context.Context, req *agentsv1.GetEnvironmen
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireEnvironmentRead(ctx, environment); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
 }
 
@@ -112,6 +122,13 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 		req.WorkspaceImageId == nil && req.WorkspaceImageTag == nil &&
 		req.AgentRuntimeImageId == nil && req.AgentRuntimeImageTag == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+	existing, err := s.store.GetEnvironment(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireEnvironmentWrite(ctx, existing); err != nil {
+		return nil, err
 	}
 	update := store.EnvironmentUpdate{}
 	if req.Name != nil {
@@ -153,6 +170,13 @@ func (s *Server) DeleteEnvironment(ctx context.Context, req *agentsv1.DeleteEnvi
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
+	}
+	existing, err := s.store.GetEnvironment(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireEnvironmentWrite(ctx, existing); err != nil {
+		return nil, err
 	}
 	if err := s.store.DeleteEnvironment(ctx, id); err != nil {
 		return nil, toStatusError(err)


### PR DESCRIPTION
`CreateEnvironment`, `GetEnvironment`, `UpdateEnvironment` and
`DeleteEnvironment` checked nothing at all. Create took an organization id and
the other three took a bare environment id with no organization scoping, so
holding an id was the whole permission — and it reached across organizations.
Only `ListEnvironments` was gated. The Gateway forwards these verbatim, as it
should, so nothing compensated downstream.

Each now resolves the organization — from the request for Create, from the
record for the rest — and requires membership of it.

Reads keep the optional-identity rule the rest of the service uses: the
Orchestrator resolves an environment while assembling every workload and holds
no tuples, so a check could only ever refuse it. Writes require an identity, as
`CreateAgent` and `CreateSandbox` already do.

## Verification

`TestEnvironmentRPCsRefuseAnotherOrganization` was run against the handlers
reverted, to check it fails for the right reason:

```
Get served an environment in another organization
Update served an environment in another organization
Delete served an environment in another organization
expected the environment to survive: environment not found
```

`Delete` destroyed another organization's environment.

The database-backed cases need `AGENTS_TEST_DATABASE_URL` and skip without it,
matching `agent_environment_test.go`.

## Scope

Membership is the floor, not the destination. The `environment` type, its roles
and `can_use` land with volumes-on-environments and tighten these to
`can_read_config`, `can_edit_config` and `can_delete`. Nothing here is reverted
by that.