### PR TITLE
Record the organization's sandbox bounds, and let a creator name one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
             --path agynio/api/authorization/v1 \
             --path agynio/api/identity/v1 \
             --path agynio/api/images/v1 \
-            --path agynio/api/notifications/v1
+            --path agynio/api/notifications/v1 \
+            --path agynio/api/organizations/v1
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN buf generate buf.build/agynio/api \
     --path agynio/api/authorization/v1 \
     --path agynio/api/identity/v1 \
     --path agynio/api/images/v1 \
-    --path agynio/api/notifications/v1
+    --path agynio/api/notifications/v1 \
+    --path agynio/api/organizations/v1
 
 COPY . .
 

--- a/cmd/agents-service/main.go
+++ b/cmd/agents-service/main.go
@@ -14,6 +14,7 @@ import (
 	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
 	imagesv1 "github.com/agynio/agents/.gen/go/agynio/api/images/v1"
 	notificationsv1 "github.com/agynio/agents/.gen/go/agynio/api/notifications/v1"
+	organizationsv1 "github.com/agynio/agents/.gen/go/agynio/api/organizations/v1"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -93,6 +94,17 @@ func run() error {
 		}()
 		agentsService.WithImages(imagesv1.NewImagesServiceClient(imagesConn))
 	}
+
+	// Required: CreateSandbox reads the organization's sandbox lifecycle bounds
+	// rather than assuming a platform-wide number.
+	organizationsConn, err := grpc.NewClient(cfg.OrganizationsGRPCTarget, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial organizations: %w", err)
+	}
+	defer func() {
+		_ = organizationsConn.Close()
+	}()
+	agentsService.WithOrganizations(organizationsv1.NewOrganizationsServiceClient(organizationsConn))
 
 	agentsv1.RegisterAgentsServiceServer(grpcServer, agentsService)
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -35,7 +35,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/images/v1 --path agynio/api/notifications/v1
+                  buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/images/v1 --path agynio/api/notifications/v1 --path agynio/api/organizations/v1
                   exec go run ./cmd/agents-service
               volumeMounts:
                 - name: data

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,9 @@ type Config struct {
 	// injects IMAGES_SERVICE_HOST and IMAGES_SERVICE_PORT for the images
 	// Service, and a third IMAGES_SERVICE_* would read as one of them.
 	ImagesGRPCTarget string
+	// Read by CreateSandbox for the organization's sandbox lifecycle bounds.
+	// Named GRPC_TARGET for the same reason as the images one.
+	OrganizationsGRPCTarget string
 	// How often idle instances are swept. Configurable mainly so a test
 	// deployment can watch the sweep without waiting a minute for it.
 	InstanceIdleGCInterval time.Duration
@@ -56,6 +59,10 @@ func FromEnv() (Config, error) {
 	cfg.NotificationsServiceAddress = os.Getenv("NOTIFICATIONS_SERVICE_ADDRESS")
 	if cfg.NotificationsServiceAddress == "" {
 		cfg.NotificationsServiceAddress = "notifications:50051"
+	}
+	cfg.OrganizationsGRPCTarget = os.Getenv("ORGANIZATIONS_GRPC_TARGET")
+	if cfg.OrganizationsGRPCTarget == "" {
+		cfg.OrganizationsGRPCTarget = "organizations:50051"
 	}
 	return cfg, nil
 }

--- a/internal/server/organizations.go
+++ b/internal/server/organizations.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	organizationsv1 "github.com/agynio/agents/.gen/go/agynio/api/organizations/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// OrganizationsClient is the slice of Organizations this service uses: the
+// sandbox lifecycle bounds a new sandbox records at creation.
+type OrganizationsClient interface {
+	GetOrganization(ctx context.Context, req *organizationsv1.GetOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.GetOrganizationResponse, error)
+}
+
+// sandboxLifecycle is what a sandbox stores at creation. Both are snapshotted:
+// changing the organization's settings afterwards never moves a live sandbox.
+type sandboxLifecycle struct {
+	IdleTimeout string
+	TTL         string
+}
+
+// resolveSandboxLifecycle settles the bounds for a new sandbox. A requested idle
+// timeout wins up to the organization's ceiling; above it the request is refused
+// naming the ceiling rather than clamped, because a silently reduced timeout is
+// a number the caller never sees and plans around wrongly.
+func (s *Server) resolveSandboxLifecycle(ctx context.Context, organizationID uuid.UUID, requested *string) (sandboxLifecycle, error) {
+	if s.organizations == nil {
+		return sandboxLifecycle{}, status.Error(codes.Internal, "organizations client is not configured")
+	}
+	response, err := s.organizations.GetOrganization(ctx, &organizationsv1.GetOrganizationRequest{Id: organizationID.String()})
+	if err != nil {
+		return sandboxLifecycle{}, err
+	}
+	organization := response.GetOrganization()
+	if organization == nil {
+		return sandboxLifecycle{}, status.Errorf(codes.NotFound, "organization %s not found", organizationID)
+	}
+
+	ceiling, err := time.ParseDuration(organization.GetSandboxMaxIdleTimeout())
+	if err != nil {
+		return sandboxLifecycle{}, status.Errorf(codes.Internal, "organization sandbox_max_idle_timeout: %v", err)
+	}
+	idleTimeout := organization.GetSandboxDefaultIdleTimeout()
+	if requested != nil {
+		idleTimeout = *requested
+		asked, err := time.ParseDuration(idleTimeout)
+		if err != nil {
+			return sandboxLifecycle{}, status.Errorf(codes.InvalidArgument, "idle_timeout: %v", err)
+		}
+		if asked <= 0 {
+			return sandboxLifecycle{}, status.Error(codes.InvalidArgument, "idle_timeout: must be greater than 0s")
+		}
+		if asked > ceiling {
+			return sandboxLifecycle{}, status.Errorf(codes.InvalidArgument,
+				"idle_timeout %s exceeds the organization's sandbox_max_idle_timeout of %s", asked, ceiling)
+		}
+	} else {
+		// Organizations keeps the two consistent on write. Should they drift,
+		// the ceiling binds: nobody asked for this number, so honouring the
+		// organization's stated maximum misleads no one, where refusing would
+		// leave it unable to start a sandbox at all.
+		fallback, err := time.ParseDuration(idleTimeout)
+		if err != nil {
+			return sandboxLifecycle{}, status.Errorf(codes.Internal, "organization sandbox_default_idle_timeout: %v", err)
+		}
+		if fallback > ceiling {
+			idleTimeout = organization.GetSandboxMaxIdleTimeout()
+		}
+	}
+	if err := validateDurationString(idleTimeout); err != nil {
+		return sandboxLifecycle{}, status.Errorf(codes.Internal, "organization sandbox_default_idle_timeout: %v", err)
+	}
+	ttl := organization.GetSandboxDefaultTtl()
+	if err := validateDurationString(ttl); err != nil {
+		return sandboxLifecycle{}, status.Errorf(codes.Internal, "organization sandbox_default_ttl: %v", err)
+	}
+	return sandboxLifecycle{IdleTimeout: idleTimeout, TTL: ttl}, nil
+}

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -19,10 +19,8 @@ import (
 )
 
 const (
-	maxSandboxNameLength      = 63
-	defaultSandboxIdleTimeout = "30m"
-	defaultSandboxTTL         = "72h"
-	maxGeneratedNameAttempts  = 8
+	maxSandboxNameLength     = 63
+	maxGeneratedNameAttempts = 8
 )
 
 var (
@@ -197,17 +195,17 @@ func (s *Server) CreateSandbox(ctx context.Context, req *agentsv1.CreateSandboxR
 		}
 		requestedName = &name
 	}
-	if err := validateDurationString(defaultSandboxIdleTimeout); err != nil {
-		return nil, status.Errorf(codes.Internal, "default sandbox idle_timeout: %v", err)
-	}
-	if err := validateDurationString(defaultSandboxTTL); err != nil {
-		return nil, status.Errorf(codes.Internal, "default sandbox ttl: %v", err)
-	}
 	ownerID, err := identityUUIDFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if err := s.requireOrganizationRelation(ctx, ownerID, organizationID, "can_create_sandbox"); err != nil {
+		return nil, err
+	}
+	// Snapshotted onto the sandbox: later changes to the organization's settings
+	// leave a live sandbox on the values it started with, as TTL already was.
+	lifecycle, err := s.resolveSandboxLifecycle(ctx, organizationID, req.IdleTimeout)
+	if err != nil {
 		return nil, err
 	}
 
@@ -218,11 +216,11 @@ func (s *Server) CreateSandbox(ctx context.Context, req *agentsv1.CreateSandboxR
 			EnvironmentID: environmentID,
 			OwnerID:       ownerID,
 			Status:        store.SandboxStatusStarting,
-			IdleTimeout:   defaultSandboxIdleTimeout,
-			TTL:           defaultSandboxTTL,
+			IdleTimeout:   lifecycle.IdleTimeout,
+			TTL:           lifecycle.TTL,
 		})
 	} else {
-		sandbox, err = s.createSandboxWithGeneratedName(ctx, organizationID, environmentID, ownerID)
+		sandbox, err = s.createSandboxWithGeneratedName(ctx, organizationID, environmentID, ownerID, lifecycle)
 	}
 	if err != nil {
 		return nil, toStatusError(err)
@@ -472,15 +470,15 @@ func (s *Server) UpdateSandboxLastSession(ctx context.Context, req *agentsv1.Upd
 	return &agentsv1.UpdateSandboxLastSessionResponse{Sandbox: toProtoSandbox(sandbox)}, nil
 }
 
-func (s *Server) createSandboxWithGeneratedName(ctx context.Context, organizationID uuid.UUID, environmentID uuid.UUID, ownerID uuid.UUID) (store.Sandbox, error) {
+func (s *Server) createSandboxWithGeneratedName(ctx context.Context, organizationID uuid.UUID, environmentID uuid.UUID, ownerID uuid.UUID, lifecycle sandboxLifecycle) (store.Sandbox, error) {
 	create := func(name string) (store.Sandbox, error) {
 		return s.store.CreateSandbox(ctx, organizationID, store.SandboxInput{
 			Name:          name,
 			EnvironmentID: environmentID,
 			OwnerID:       ownerID,
 			Status:        store.SandboxStatusStarting,
-			IdleTimeout:   defaultSandboxIdleTimeout,
-			TTL:           defaultSandboxTTL,
+			IdleTimeout:   lifecycle.IdleTimeout,
+			TTL:           lifecycle.TTL,
 		})
 	}
 	return createSandboxWithGeneratedName(maxGeneratedNameAttempts, generateSandboxName, create)

--- a/internal/server/sandbox_idle_timeout_test.go
+++ b/internal/server/sandbox_idle_timeout_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	organizationsv1 "github.com/agynio/agents/.gen/go/agynio/api/organizations/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Every sandbox in an organization used to get one hardcoded number: the
+// organization's own settings were written and validated by Organizations and
+// read by nobody. What follows is what a new sandbox now records.
+
+type stubOrganizationsClient struct {
+	organization *organizationsv1.Organization
+	err          error
+	requested    []string
+}
+
+func (c *stubOrganizationsClient) GetOrganization(_ context.Context, req *organizationsv1.GetOrganizationRequest, _ ...grpc.CallOption) (*organizationsv1.GetOrganizationResponse, error) {
+	c.requested = append(c.requested, req.GetId())
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &organizationsv1.GetOrganizationResponse{Organization: c.organization}, nil
+}
+
+func organizationsStub(defaultIdle, maxIdle, ttl string) *stubOrganizationsClient {
+	return &stubOrganizationsClient{organization: &organizationsv1.Organization{
+		SandboxDefaultIdleTimeout: defaultIdle,
+		SandboxMaxIdleTimeout:     maxIdle,
+		SandboxDefaultTtl:         ttl,
+	}}
+}
+
+func TestSandboxLifecycleUsesTheOrganizationDefault(t *testing.T) {
+	organizations := organizationsStub("45m", "8h", "96h")
+	server := &Server{organizations: organizations}
+	organizationID := uuid.New()
+
+	lifecycle, err := server.resolveSandboxLifecycle(context.Background(), organizationID, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if lifecycle.IdleTimeout != "45m" {
+		t.Fatalf("expected the organization default 45m, got %q", lifecycle.IdleTimeout)
+	}
+	if lifecycle.TTL != "96h" {
+		t.Fatalf("expected the organization ttl 96h, got %q", lifecycle.TTL)
+	}
+	if len(organizations.requested) != 1 || organizations.requested[0] != organizationID.String() {
+		t.Fatalf("expected the sandbox's own organization to be read, got %v", organizations.requested)
+	}
+}
+
+func TestSandboxLifecycleAcceptsARequestedTimeout(t *testing.T) {
+	server := &Server{organizations: organizationsStub("30m", "8h", "72h")}
+
+	lifecycle, err := server.resolveSandboxLifecycle(context.Background(), uuid.New(), strPtr("4h"))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if lifecycle.IdleTimeout != "4h" {
+		t.Fatalf("expected the requested 4h, got %q", lifecycle.IdleTimeout)
+	}
+}
+
+// Naming the ceiling is the point: a silently clamped timeout is a number the
+// engineer never sees and plans around wrongly.
+func TestSandboxLifecycleRefusesAboveTheCeilingAndNamesIt(t *testing.T) {
+	server := &Server{organizations: organizationsStub("30m", "2h", "72h")}
+
+	_, err := server.resolveSandboxLifecycle(context.Background(), uuid.New(), strPtr("6h"))
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "2h") {
+		t.Fatalf("expected the error to name the ceiling, got %q", err.Error())
+	}
+}
+
+func TestSandboxLifecycleAcceptsExactlyTheCeiling(t *testing.T) {
+	server := &Server{organizations: organizationsStub("30m", "2h", "72h")}
+
+	lifecycle, err := server.resolveSandboxLifecycle(context.Background(), uuid.New(), strPtr("2h"))
+	if err != nil {
+		t.Fatalf("the ceiling itself must be allowed: %v", err)
+	}
+	if lifecycle.IdleTimeout != "2h" {
+		t.Fatalf("expected 2h, got %q", lifecycle.IdleTimeout)
+	}
+}
+
+func TestSandboxLifecycleRejectsAMalformedRequest(t *testing.T) {
+	server := &Server{organizations: organizationsStub("30m", "8h", "72h")}
+
+	for _, value := range []string{"soon", "0s", "-1h"} {
+		if _, err := server.resolveSandboxLifecycle(context.Background(), uuid.New(), strPtr(value)); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("%q: expected InvalidArgument, got %v", value, err)
+		}
+	}
+}
+
+// A default above the ceiling is Organizations' invariant to keep. Should the
+// two drift, a sandbox that names nothing must not be handed a value the
+// organization refuses to anyone who asks for it.
+func TestSandboxLifecycleBindsADriftedDefaultToTheCeiling(t *testing.T) {
+	server := &Server{organizations: organizationsStub("6h", "2h", "72h")}
+
+	lifecycle, err := server.resolveSandboxLifecycle(context.Background(), uuid.New(), nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if lifecycle.IdleTimeout != "2h" {
+		t.Fatalf("expected the ceiling 2h to bind the drifted default, got %q", lifecycle.IdleTimeout)
+	}
+}
+
+func strPtr(value string) *string { return &value }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,13 @@ type Server struct {
 	// Optional: without it, image references are stored unvalidated and the
 	// orchestrator resolves them again at workload start.
 	images ImagesClient
+	// Required by CreateSandbox, which reads the organization's sandbox
+	// lifecycle bounds rather than assuming a platform-wide number.
+	organizations OrganizationsClient
+}
+
+func (s *Server) WithOrganizations(client OrganizationsClient) {
+	s.organizations = client
 }
 
 const (


### PR DESCRIPTION
`CreateSandbox` wrote two package constants onto every sandbox it made.
`sandbox_default_idle_timeout` and `sandbox_default_ttl` were validated and
stored by Organizations and then read by nobody, so an organization could not
move either number and no caller could ask for one.

The change doc for this says the service "snapshots
`organization.sandbox_default_idle_timeout` at creation". It does not, and never
did — hence the new client dependency here, which is scope the doc does not
mention.

## Changes

- Organizations client, wired like the Images one but required: falling back to
  a constant is the bug being fixed, not a degraded mode worth keeping.
- `CreateSandbox` takes `idle_timeout`, accepted up to
  `sandbox_max_idle_timeout` and refused above it naming the ceiling rather than
  clamped. A silently reduced timeout is a number the engineer never sees and
  plans around wrongly.
- Both values snapshotted at creation, as TTL already was.

Should an organization's default and ceiling drift apart, the ceiling binds a
sandbox that names nothing — nobody asked for that number, and refusing would
leave the organization unable to start a sandbox at all. A test covers it.

The CI job and the image build did not ask for the organizations bindings, so
both now do.

Requires agynio/api#176 (merged and published).

Spec: `architecture/changes/2026-08-06-sandbox-idle-timeout-control.md`