### PR TITLE
Move volumes, MCPs and init scripts onto environments

### DIFF
--- a/cmd/agents-service/main.go
+++ b/cmd/agents-service/main.go
@@ -96,6 +96,10 @@ func run() error {
 
 	agentsv1.RegisterAgentsServiceServer(grpcServer, agentsService)
 
+	// Environments predating the environment authorization type carry no tuples,
+	// so every check against them refuses. Idempotent, and runs before serving.
+	agentsService.BackfillEnvironmentAuthorization(ctx)
+
 	// Instances whose class sets an idle limit are paused once they pass it.
 	// Started before Serve so a service that never receives a request still
 	// reclaims what earlier runs left behind.

--- a/internal/server/agent_environment_test.go
+++ b/internal/server/agent_environment_test.go
@@ -53,6 +53,7 @@ func createTestEnvironment(ctx context.Context, t *testing.T, server *Server, or
 		Name:           name,
 		Image:          "ghcr.io/agynio/environment:latest",
 		Flavor:         "small",
+		Availability:   agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL,
 	})
 	if err != nil {
 		t.Fatalf("create environment: %v", err)

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -89,6 +89,24 @@ func (s *Server) requireOrganizationListAccess(ctx context.Context, organization
 	return s.requireOrganizationMember(ctx, identityID, organizationID)
 }
 
+// requireEnvironmentRead authorizes reading one environment. An identified
+// caller must be a member of its organization; an internal caller holds no
+// tuples and is served, as the Orchestrator reads environments while assembling
+// workloads.
+func (s *Server) requireEnvironmentRead(ctx context.Context, environment store.Environment) error {
+	return s.requireOrganizationListAccess(ctx, environment.OrganizationID)
+}
+
+// requireEnvironmentWrite authorizes changing an environment or anything it
+// owns. These RPCs have no internal callers, so an identity is required.
+func (s *Server) requireEnvironmentWrite(ctx context.Context, environment store.Environment) error {
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	return s.requireOrganizationMember(ctx, identityID, environment.OrganizationID)
+}
+
 func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) error {
 	return s.requireAllowed(ctx, identityID, relation, organizationPrefix+organizationID.String(), status.Errorf(codes.PermissionDenied, "identity lacks %s on organization", relation))
 }

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -17,6 +17,7 @@ const (
 	agentPrefix         = "agent:"
 	agentInstancePrefix = "agent_instance:"
 	sandboxPrefix       = "sandbox:"
+	environmentPrefix   = "environment:"
 )
 
 type AuthorizationWriter interface {
@@ -104,7 +105,98 @@ func (s *Server) requireEnvironmentWrite(ctx context.Context, environment store.
 	if err != nil {
 		return err
 	}
-	return s.requireOrganizationMember(ctx, identityID, environment.OrganizationID)
+	return s.requireEnvironmentRelation(ctx, identityID, environment.Meta.ID, "can_edit_config")
+}
+
+// requireEnvironmentUse gates running a workload in an environment. A shell in
+// a sandbox there reaches the environment's secrets, egress credentials and
+// volume contents, so this is a grant rather than a consequence of visibility.
+func (s *Server) requireEnvironmentUse(ctx context.Context, environmentID uuid.UUID) error {
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasIdentity {
+		return nil
+	}
+	return s.requireEnvironmentRelation(ctx, identityID, environmentID, "can_use")
+}
+
+func environmentOrganizationTuple(environmentID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     organizationPrefix + organizationID.String(),
+		Relation: "org",
+		Object:   environmentPrefix + environmentID.String(),
+	}
+}
+
+func environmentInternalAccessTuple(environmentID uuid.UUID, organizationID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     organizationPrefix + organizationID.String(),
+		Relation: "internal_access",
+		Object:   environmentPrefix + environmentID.String(),
+	}
+}
+
+func environmentRoleTuple(environmentID uuid.UUID, identityID uuid.UUID, role store.EnvironmentRole) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + identityID.String(),
+		Relation: string(role),
+		Object:   environmentPrefix + environmentID.String(),
+	}
+}
+
+func (s *Server) addEnvironmentAuthorization(ctx context.Context, environmentID, organizationID, creatorID uuid.UUID, availability store.EnvironmentAvailability) error {
+	writes := []*authorizationv1.TupleKey{
+		environmentOrganizationTuple(environmentID, organizationID),
+		environmentRoleTuple(environmentID, creatorID, store.EnvironmentRoleOwner),
+	}
+	if availability == store.EnvironmentAvailabilityInternal {
+		writes = append(writes, environmentInternalAccessTuple(environmentID, organizationID))
+	}
+	return s.writeAuthorization(ctx, writes, nil)
+}
+
+func (s *Server) removeEnvironmentAuthorization(ctx context.Context, environmentID, organizationID uuid.UUID, roles []store.EnvironmentRoleAssignment, availability store.EnvironmentAvailability) error {
+	deletes := []*authorizationv1.TupleKey{environmentOrganizationTuple(environmentID, organizationID)}
+	if availability == store.EnvironmentAvailabilityInternal {
+		deletes = append(deletes, environmentInternalAccessTuple(environmentID, organizationID))
+	}
+	for _, role := range roles {
+		deletes = append(deletes, environmentRoleTuple(environmentID, role.IdentityID, role.Role))
+	}
+	return s.writeAuthorization(ctx, nil, deletes)
+}
+
+func (s *Server) updateEnvironmentAvailabilityAuthorization(ctx context.Context, environmentID, organizationID uuid.UUID, previous, next store.EnvironmentAvailability) error {
+	if previous == next {
+		return nil
+	}
+	tuple := environmentInternalAccessTuple(environmentID, organizationID)
+	if next == store.EnvironmentAvailabilityInternal {
+		return s.writeAuthorization(ctx, []*authorizationv1.TupleKey{tuple}, nil)
+	}
+	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{tuple})
+}
+
+func (s *Server) updateEnvironmentRoleAuthorization(ctx context.Context, environmentID, identityID uuid.UUID, previous *store.EnvironmentRole, next store.EnvironmentRole) error {
+	var deletes []*authorizationv1.TupleKey
+	if previous != nil {
+		if *previous == next {
+			return nil
+		}
+		deletes = append(deletes, environmentRoleTuple(environmentID, identityID, *previous))
+	}
+	return s.writeAuthorization(ctx, []*authorizationv1.TupleKey{environmentRoleTuple(environmentID, identityID, next)}, deletes)
+}
+
+func (s *Server) removeEnvironmentRoleAuthorization(ctx context.Context, environmentID, identityID uuid.UUID, role store.EnvironmentRole) error {
+	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{environmentRoleTuple(environmentID, identityID, role)})
+}
+
+func (s *Server) requireEnvironmentRelation(ctx context.Context, identityID uuid.UUID, environmentID uuid.UUID, relation string) error {
+	return s.requireAllowed(ctx, identityID, relation, environmentPrefix+environmentID.String(),
+		status.Errorf(codes.PermissionDenied, "identity lacks %s on environment", relation))
 }
 
 func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) error {

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"strings"
 
 	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
 	"github.com/agynio/agents/internal/store"
@@ -174,12 +175,36 @@ func (s *Server) addEnvironmentAuthorization(ctx context.Context, environmentID,
 
 // addEnvironmentBaseAuthorization writes what an environment needs to resolve
 // at all, without an owner. Used by the backfill, where no creator is recorded.
+//
+// OpenFGA refuses to write a tuple that already exists, and refuses the whole
+// batch when one of them does, so each is written on its own and an existing one
+// counts as success. Writing them together would mean an environment holding the
+// org tuple but not internal_access could never gain the second.
 func (s *Server) addEnvironmentBaseAuthorization(ctx context.Context, environmentID, organizationID uuid.UUID, availability store.EnvironmentAvailability) error {
-	writes := []*authorizationv1.TupleKey{environmentOrganizationTuple(environmentID, organizationID)}
+	tuples := []*authorizationv1.TupleKey{environmentOrganizationTuple(environmentID, organizationID)}
 	if availability == store.EnvironmentAvailabilityInternal {
-		writes = append(writes, environmentInternalAccessTuple(environmentID, organizationID))
+		tuples = append(tuples, environmentInternalAccessTuple(environmentID, organizationID))
 	}
-	return s.writeAuthorization(ctx, writes, nil)
+	for _, tuple := range tuples {
+		if err := s.writeAuthorization(ctx, []*authorizationv1.TupleKey{tuple}, nil); err != nil {
+			if isTupleAlreadyExists(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// isTupleAlreadyExists reports the write OpenFGA refuses because the tuple is
+// already there, which for a repair pass is the desired end state.
+func isTupleAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "already exists") ||
+		strings.Contains(message, "write_failed_due_to_invalid_input")
 }
 
 func (s *Server) removeEnvironmentAuthorization(ctx context.Context, environmentID, organizationID uuid.UUID, roles []store.EnvironmentRoleAssignment, availability store.EnvironmentAvailability) error {

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -157,6 +157,16 @@ func (s *Server) addEnvironmentAuthorization(ctx context.Context, environmentID,
 	return s.writeAuthorization(ctx, writes, nil)
 }
 
+// addEnvironmentBaseAuthorization writes what an environment needs to resolve
+// at all, without an owner. Used by the backfill, where no creator is recorded.
+func (s *Server) addEnvironmentBaseAuthorization(ctx context.Context, environmentID, organizationID uuid.UUID, availability store.EnvironmentAvailability) error {
+	writes := []*authorizationv1.TupleKey{environmentOrganizationTuple(environmentID, organizationID)}
+	if availability == store.EnvironmentAvailabilityInternal {
+		writes = append(writes, environmentInternalAccessTuple(environmentID, organizationID))
+	}
+	return s.writeAuthorization(ctx, writes, nil)
+}
+
 func (s *Server) removeEnvironmentAuthorization(ctx context.Context, environmentID, organizationID uuid.UUID, roles []store.EnvironmentRoleAssignment, availability store.EnvironmentAvailability) error {
 	deletes := []*authorizationv1.TupleKey{environmentOrganizationTuple(environmentID, organizationID)}
 	if availability == store.EnvironmentAvailabilityInternal {

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -98,6 +98,21 @@ func (s *Server) requireEnvironmentRead(ctx context.Context, environment store.E
 	return s.requireOrganizationListAccess(ctx, environment.OrganizationID)
 }
 
+// requireEnvironmentConfigRead authorizes reading what an environment contains,
+// as distinct from its metadata: the volumes, servers, scripts and variables a
+// workload there carries. An internal caller holds no tuples and is served, as
+// the Orchestrator reads all of it while assembling workloads.
+func (s *Server) requireEnvironmentConfigRead(ctx context.Context, environmentID uuid.UUID) error {
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasIdentity {
+		return nil
+	}
+	return s.requireEnvironmentRelation(ctx, identityID, environmentID, "can_read_config")
+}
+
 // requireEnvironmentWrite authorizes changing an environment or anything it
 // owns. These RPCs have no internal callers, so an identity is required.
 func (s *Server) requireEnvironmentWrite(ctx context.Context, environment store.Environment) error {

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -66,34 +66,23 @@ func toProtoAgentRoleAssignment(assignment store.AgentRoleAssignment) *agentsv1.
 }
 
 func toProtoVolume(volume store.Volume) *agentsv1.Volume {
-	// TODO: Populate OrganizationId once included in Volume response proto.
 	protoVolume := &agentsv1.Volume{
-		Meta:        toProtoEntityMeta(volume.Meta),
-		Persistent:  volume.Persistent,
-		MountPath:   volume.MountPath,
-		Size:        volume.Size,
-		Description: volume.Description,
+		Meta:       toProtoEntityMeta(volume.Meta),
+		Name:       volume.Name,
+		MountPath:  volume.MountPath,
+		Persistent: volume.Persistent,
 	}
-	if volume.TTL != nil {
-		protoVolume.Ttl = volume.TTL
+	if volume.Size != nil {
+		protoVolume.Size = *volume.Size
+	}
+	protoVolume.StorageClass = volume.StorageClass
+	protoVolume.Ttl = volume.TTL
+	if volume.EnvironmentID != nil {
+		protoVolume.Target = &agentsv1.Volume_EnvironmentId{EnvironmentId: volume.EnvironmentID.String()}
+	} else if volume.McpID != nil {
+		protoVolume.Target = &agentsv1.Volume_McpId{McpId: volume.McpID.String()}
 	}
 	return protoVolume
-}
-
-func toProtoVolumeAttachment(attachment store.VolumeAttachment) *agentsv1.VolumeAttachment {
-	protoAttachment := &agentsv1.VolumeAttachment{
-		Meta:     toProtoEntityMeta(attachment.Meta),
-		VolumeId: attachment.VolumeID.String(),
-	}
-	if attachment.AgentID != nil {
-		protoAttachment.Target = &agentsv1.VolumeAttachment_AgentId{AgentId: attachment.AgentID.String()}
-		return protoAttachment
-	}
-	if attachment.McpID != nil {
-		protoAttachment.Target = &agentsv1.VolumeAttachment_McpId{McpId: attachment.McpID.String()}
-		return protoAttachment
-	}
-	panic("volume attachment missing target")
 }
 
 func toProtoEnvironment(environment store.Environment) *agentsv1.Environment {
@@ -147,20 +136,25 @@ func toProtoSandbox(sandbox store.Sandbox) *agentsv1.Sandbox {
 }
 
 func toProtoMcp(mcp store.Mcp) *agentsv1.Mcp {
-	proto := &agentsv1.Mcp{
-		Meta:        toProtoEntityMeta(mcp.Meta),
-		AgentId:     mcp.AgentID.String(),
-		Name:        mcp.Name,
-		Image:       mcp.Image,
-		Command:     mcp.Command,
-		Resources:   toProtoComputeResources(mcp.Resources),
-		Description: mcp.Description,
+	protoMcp := &agentsv1.Mcp{
+		Meta:          toProtoEntityMeta(mcp.Meta),
+		Name:          mcp.Name,
+		Image:         mcp.Image,
+		Command:       mcp.Command,
+		Resources:     toProtoComputeResources(mcp.Resources),
+		Description:   mcp.Description,
+		ImageTag:      mcp.ImageTag,
+		SharedVolumes: mcp.SharedVolumes,
 	}
 	if mcp.ImageID != nil {
-		proto.ImageId = mcp.ImageID.String()
-		proto.ImageTag = mcp.ImageTag
+		protoMcp.ImageId = mcp.ImageID.String()
 	}
-	return proto
+	if mcp.EnvironmentID != nil {
+		protoMcp.Target = &agentsv1.Mcp_EnvironmentId{EnvironmentId: mcp.EnvironmentID.String()}
+	} else if mcp.AgentID != nil {
+		protoMcp.Target = &agentsv1.Mcp_AgentId{AgentId: mcp.AgentID.String()}
+	}
+	return protoMcp
 }
 
 func toProtoSkill(skill store.Skill) *agentsv1.Skill {
@@ -208,6 +202,10 @@ func toProtoInitScript(script store.InitScript) *agentsv1.InitScript {
 	}
 	if script.AgentID != nil {
 		protoScript.Target = &agentsv1.InitScript_AgentId{AgentId: script.AgentID.String()}
+		return protoScript
+	}
+	if script.EnvironmentID != nil {
+		protoScript.Target = &agentsv1.InitScript_EnvironmentId{EnvironmentId: script.EnvironmentID.String()}
 		return protoScript
 	}
 	if script.McpID != nil {

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -150,9 +150,10 @@ func toProtoMcp(mcp store.Mcp) *agentsv1.Mcp {
 		protoMcp.ImageId = mcp.ImageID.String()
 	}
 	if mcp.EnvironmentID != nil {
-		protoMcp.Target = &agentsv1.Mcp_EnvironmentId{EnvironmentId: mcp.EnvironmentID.String()}
-	} else if mcp.AgentID != nil {
-		protoMcp.Target = &agentsv1.Mcp_AgentId{AgentId: mcp.AgentID.String()}
+		protoMcp.EnvironmentId = mcp.EnvironmentID.String()
+	}
+	if mcp.AgentID != nil {
+		protoMcp.AgentId = mcp.AgentID.String()
 	}
 	return protoMcp
 }

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -21,17 +21,18 @@ import (
 
 func TestToProtoVolumeIncludesTTL(t *testing.T) {
 	ttl := "24h"
+	size := "1Gi"
 	volume := store.Volume{
 		Meta: store.EntityMeta{
 			ID:        uuid.New(),
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
-		Persistent:  true,
-		MountPath:   "/data",
-		Size:        "1Gi",
-		Description: "volume",
-		TTL:         &ttl,
+		Persistent: true,
+		MountPath:  "/data",
+		Name:       "data",
+		Size:       &size,
+		TTL:        &ttl,
 	}
 
 	protoVolume := toProtoVolume(volume)
@@ -44,16 +45,17 @@ func TestToProtoVolumeIncludesTTL(t *testing.T) {
 }
 
 func TestToProtoVolumeOmitsTTLWhenNil(t *testing.T) {
+	size := "1Gi"
 	volume := store.Volume{
 		Meta: store.EntityMeta{
 			ID:        uuid.New(),
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
-		Persistent:  true,
-		MountPath:   "/data",
-		Size:        "1Gi",
-		Description: "volume",
+		Persistent: true,
+		MountPath:  "/data",
+		Name:       "data",
+		Size:       &size,
 	}
 
 	protoVolume := toProtoVolume(volume)

--- a/internal/server/environment_backfill.go
+++ b/internal/server/environment_backfill.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"log"
+
+	"github.com/agynio/agents/internal/store"
+)
+
+// BackfillEnvironmentAuthorization writes the tuples every environment created
+// before the environment type existed is missing.
+//
+// can_edit_config and can_delete resolve through `owner from org`, so without
+// an org tuple an environment answers no to every caller, including the
+// organization's owner. There is no creator on the record to restore an owner
+// tuple from, and inventing one would hand an environment to whoever happened
+// to be looked up first; organization owners reach it through `owner from org`
+// instead, which is what the org tuple is for.
+//
+// Writes are idempotent, so this runs on every startup rather than once behind
+// a marker: a tuple that already exists is written again to the same value.
+func (s *Server) BackfillEnvironmentAuthorization(ctx context.Context) {
+	var cursor *store.PageCursor
+	backfilled := 0
+	for {
+		result, err := s.store.ListAllEnvironments(ctx, backfillPageSize, cursor)
+		if err != nil {
+			log.Printf("agents: backfill environment authorization: list: %v", err)
+			return
+		}
+		for _, environment := range result.Environments {
+			if err := s.writeEnvironmentBaseTuples(ctx, environment); err != nil {
+				log.Printf("agents: backfill environment %s: %v", environment.Meta.ID, err)
+				continue
+			}
+			backfilled++
+		}
+		if result.NextCursor == nil {
+			break
+		}
+		cursor = result.NextCursor
+	}
+	if backfilled > 0 {
+		log.Printf("agents: backfilled authorization for %d environment(s)", backfilled)
+	}
+}
+
+const backfillPageSize = 100
+
+func (s *Server) writeEnvironmentBaseTuples(ctx context.Context, environment store.Environment) error {
+	availability := environment.Availability
+	if availability == "" {
+		availability = store.EnvironmentAvailabilityInternal
+	}
+	return s.addEnvironmentBaseAuthorization(ctx, environment.Meta.ID, environment.OrganizationID, availability)
+}

--- a/internal/server/environment_backfill_test.go
+++ b/internal/server/environment_backfill_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+// OpenFGA refuses to write a tuple that already exists, and refuses the whole
+// batch when one of them does. A repair pass runs on every startup, so the
+// second run must not fail on what the first wrote.
+type existingTupleWriter struct {
+	existing map[string]bool
+	attempts int
+}
+
+func (w *existingTupleWriter) Check(context.Context, *authorizationv1.CheckRequest, ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	return &authorizationv1.CheckResponse{Allowed: true}, nil
+}
+
+func (w *existingTupleWriter) Write(_ context.Context, req *authorizationv1.WriteRequest, _ ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	w.attempts++
+	for _, tuple := range req.GetWrites() {
+		key := tuple.GetUser() + "|" + tuple.GetRelation() + "|" + tuple.GetObject()
+		if w.existing[key] {
+			return nil, errors.New("cannot write a tuple which already exists: " + key)
+		}
+		w.existing[key] = true
+	}
+	return &authorizationv1.WriteResponse{}, nil
+}
+
+func TestEnvironmentBackfillIsIdempotent(t *testing.T) {
+	authz := &existingTupleWriter{existing: map[string]bool{}}
+	server := &Server{authz: authz}
+	environmentID := uuid.New()
+	organizationID := uuid.New()
+
+	for run := 1; run <= 2; run++ {
+		if err := server.addEnvironmentBaseAuthorization(context.Background(), environmentID, organizationID, store.EnvironmentAvailabilityInternal); err != nil {
+			t.Fatalf("run %d: %v", run, err)
+		}
+	}
+	if len(authz.existing) != 2 {
+		t.Fatalf("expected the org and internal_access tuples, got %d", len(authz.existing))
+	}
+}
+
+// A batch write would leave an environment holding one tuple unable to gain the
+// other, because the batch fails on the one that exists.
+func TestEnvironmentBackfillRepairsAPartialEnvironment(t *testing.T) {
+	environmentID := uuid.New()
+	organizationID := uuid.New()
+	orgTuple := environmentOrganizationTuple(environmentID, organizationID)
+	authz := &existingTupleWriter{existing: map[string]bool{
+		orgTuple.GetUser() + "|" + orgTuple.GetRelation() + "|" + orgTuple.GetObject(): true,
+	}}
+	server := &Server{authz: authz}
+
+	if err := server.addEnvironmentBaseAuthorization(context.Background(), environmentID, organizationID, store.EnvironmentAvailabilityInternal); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	internalAccess := environmentInternalAccessTuple(environmentID, organizationID)
+	key := internalAccess.GetUser() + "|" + internalAccess.GetRelation() + "|" + internalAccess.GetObject()
+	if !authz.existing[key] {
+		t.Fatal("expected the missing internal_access tuple to be written")
+	}
+}

--- a/internal/server/environment_roles.go
+++ b/internal/server/environment_roles.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"context"
+
+	"errors"
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/agents/internal/store"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *Server) SetEnvironmentRole(ctx context.Context, req *agentsv1.SetEnvironmentRoleRequest) (*agentsv1.SetEnvironmentRoleResponse, error) {
+	environmentID, err := parseUUID(req.GetEnvironmentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	role, err := environmentRoleFromProto(req.GetRole())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "role: %v", err)
+	}
+	environment, err := s.store.GetEnvironment(ctx, environmentID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	callerID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireEnvironmentRelation(ctx, callerID, environmentID, "can_manage_roles"); err != nil {
+		return nil, err
+	}
+	// A role on an environment reaches its secrets and volume contents, so the
+	// grantee must already belong to the organization that owns it.
+	if err := s.requireOrganizationMember(ctx, identityID, environment.OrganizationID); err != nil {
+		return nil, err
+	}
+
+	assignment := store.EnvironmentRoleAssignment{EnvironmentID: environmentID, IdentityID: identityID, Role: role}
+	previous, err := s.store.UpsertEnvironmentRole(ctx, assignment)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.updateEnvironmentRoleAuthorization(ctx, environmentID, identityID, previous, role); err != nil {
+		return nil, err
+	}
+	s.publishEnvironmentUpdated(ctx, environmentID, environment.OrganizationID)
+	return &agentsv1.SetEnvironmentRoleResponse{Assignment: toProtoEnvironmentRoleAssignment(assignment)}, nil
+}
+
+func (s *Server) RemoveEnvironmentRole(ctx context.Context, req *agentsv1.RemoveEnvironmentRoleRequest) (*agentsv1.RemoveEnvironmentRoleResponse, error) {
+	environmentID, err := parseUUID(req.GetEnvironmentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	environment, err := s.store.GetEnvironment(ctx, environmentID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	callerID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireEnvironmentRelation(ctx, callerID, environmentID, "can_manage_roles"); err != nil {
+		return nil, err
+	}
+	role, err := s.store.DeleteEnvironmentRole(ctx, environmentID, identityID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.removeEnvironmentRoleAuthorization(ctx, environmentID, identityID, role); err != nil {
+		return nil, err
+	}
+	s.publishEnvironmentUpdated(ctx, environmentID, environment.OrganizationID)
+	return &agentsv1.RemoveEnvironmentRoleResponse{}, nil
+}
+
+func (s *Server) ListEnvironmentRoles(ctx context.Context, req *agentsv1.ListEnvironmentRolesRequest) (*agentsv1.ListEnvironmentRolesResponse, error) {
+	environmentID, err := parseUUID(req.GetEnvironmentId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+	}
+	if _, err := s.store.GetEnvironment(ctx, environmentID); err != nil {
+		return nil, toStatusError(err)
+	}
+	callerID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireEnvironmentRelation(ctx, callerID, environmentID, "can_manage_roles"); err != nil {
+		return nil, err
+	}
+	assignments, err := s.store.ListEnvironmentRoles(ctx, environmentID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	response := &agentsv1.ListEnvironmentRolesResponse{Assignments: make([]*agentsv1.EnvironmentRoleAssignment, len(assignments))}
+	for i, assignment := range assignments {
+		response.Assignments[i] = toProtoEnvironmentRoleAssignment(assignment)
+	}
+	return response, nil
+}
+
+func environmentRoleFromProto(role agentsv1.EnvironmentRole) (store.EnvironmentRole, error) {
+	switch role {
+	case agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_OWNER:
+		return store.EnvironmentRoleOwner, nil
+	case agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_MAINTAINER:
+		return store.EnvironmentRoleMaintainer, nil
+	case agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_USER:
+		return store.EnvironmentRoleUser, nil
+	default:
+		return "", errUnknownEnvironmentRole
+	}
+}
+
+func toProtoEnvironmentRoleAssignment(assignment store.EnvironmentRoleAssignment) *agentsv1.EnvironmentRoleAssignment {
+	role := agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_UNSPECIFIED
+	switch assignment.Role {
+	case store.EnvironmentRoleOwner:
+		role = agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_OWNER
+	case store.EnvironmentRoleMaintainer:
+		role = agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_MAINTAINER
+	case store.EnvironmentRoleUser:
+		role = agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_USER
+	}
+	return &agentsv1.EnvironmentRoleAssignment{
+		EnvironmentId: assignment.EnvironmentID.String(),
+		IdentityId:    assignment.IdentityID.String(),
+		Role:          role,
+	}
+}
+
+var errUnknownEnvironmentRole = errors.New("must be owner, maintainer or user")

--- a/internal/server/environment_roles_test.go
+++ b/internal/server/environment_roles_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	authorizationv1 "github.com/agynio/agents/.gen/go/agynio/api/authorization/v1"
+	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
+)
+
+// `user` is the role that matters most: it opens an interactive shell onto the
+// environment's secrets, egress credentials and volume contents, without any
+// configuration access.
+func TestEnvironmentRoleTuplesFollowTheGrant(t *testing.T) {
+	environmentID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.updateEnvironmentRoleAuthorization(context.Background(), environmentID, identityID, nil, store.EnvironmentRoleUser); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), []*authorizationv1.TupleKey{
+		{User: identityPrefix + identityID.String(), Relation: "user", Object: environmentPrefix + environmentID.String()},
+	})
+	if len(request.GetDeletes()) != 0 {
+		t.Fatalf("expected no deletes on a first grant, got %d", len(request.GetDeletes()))
+	}
+}
+
+// Changing a role replaces the tuple rather than adding a second one, or the
+// identity would hold both.
+func TestEnvironmentRoleChangeReplacesThePreviousTuple(t *testing.T) {
+	environmentID := uuid.New()
+	identityID := uuid.New()
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	previous := store.EnvironmentRoleUser
+
+	if err := server.updateEnvironmentRoleAuthorization(context.Background(), environmentID, identityID, &previous, store.EnvironmentRoleMaintainer); err != nil {
+		t.Fatalf("change: %v", err)
+	}
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetWrites(), []*authorizationv1.TupleKey{
+		{User: identityPrefix + identityID.String(), Relation: "maintainer", Object: environmentPrefix + environmentID.String()},
+	})
+	assertTuples(t, request.GetDeletes(), []*authorizationv1.TupleKey{
+		{User: identityPrefix + identityID.String(), Relation: "user", Object: environmentPrefix + environmentID.String()},
+	})
+}
+
+// availability drives internal_access exactly as it does on agents: internal
+// resolves every org member to can_use, private leaves only role holders.
+func TestEnvironmentAvailabilityMovesInternalAccess(t *testing.T) {
+	environmentID := uuid.New()
+	organizationID := uuid.New()
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+
+	if err := server.updateEnvironmentAvailabilityAuthorization(context.Background(), environmentID, organizationID,
+		store.EnvironmentAvailabilityInternal, store.EnvironmentAvailabilityPrivate); err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	request := singleWriteRequest(t, authz)
+	assertTuples(t, request.GetDeletes(), []*authorizationv1.TupleKey{
+		{User: organizationPrefix + organizationID.String(), Relation: "internal_access", Object: environmentPrefix + environmentID.String()},
+	})
+}
+
+func TestEnvironmentRoleFromProtoRejectsUnspecified(t *testing.T) {
+	if _, err := environmentRoleFromProto(agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_UNSPECIFIED); err == nil {
+		t.Fatal("expected an unspecified role to be refused")
+	}
+	for _, role := range []agentsv1.EnvironmentRole{
+		agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_OWNER,
+		agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_MAINTAINER,
+		agentsv1.EnvironmentRole_ENVIRONMENT_ROLE_USER,
+	} {
+		if _, err := environmentRoleFromProto(role); err != nil {
+			t.Fatalf("role %v: %v", role, err)
+		}
+	}
+}

--- a/internal/server/environment_scope_db_test.go
+++ b/internal/server/environment_scope_db_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/google/uuid"
+)
+
+// A filter field reaching the struct but not the query returns every row, and
+// the caller cannot tell: an environment listing showed every MCP in the
+// database. These go through the handler against a real database, which is the
+// only place that shows.
+func TestEnvironmentScopedListsAreScoped(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+
+	first := createTestEnvironment(ctx, t, server, organizationID, "first")
+	second := createTestEnvironment(ctx, t, server, organizationID, "second")
+
+	mustCreateMcp(ctx, t, server, first, "alpha")
+	mustCreateMcp(ctx, t, server, second, "beta")
+	mustCreateVolume(ctx, t, server, first, "data", "/data")
+	mustCreateVolume(ctx, t, server, second, "cache", "/cache")
+
+	mcps, err := server.ListMcps(ctx, &agentsv1.ListMcpsRequest{EnvironmentId: first})
+	if err != nil {
+		t.Fatalf("list mcps: %v", err)
+	}
+	if len(mcps.GetMcps()) != 1 || mcps.GetMcps()[0].GetName() != "alpha" {
+		t.Fatalf("expected only the first environment's server, got %d", len(mcps.GetMcps()))
+	}
+
+	volumes, err := server.ListVolumes(ctx, &agentsv1.ListVolumesRequest{EnvironmentId: second})
+	if err != nil {
+		t.Fatalf("list volumes: %v", err)
+	}
+	if len(volumes.GetVolumes()) != 1 || volumes.GetVolumes()[0].GetName() != "cache" {
+		t.Fatalf("expected only the second environment's volume, got %d", len(volumes.GetVolumes()))
+	}
+
+	scripts, err := server.ListInitScripts(ctx, &agentsv1.ListInitScriptsRequest{EnvironmentId: first})
+	if err != nil {
+		t.Fatalf("list init scripts: %v", err)
+	}
+	if len(scripts.GetInitScripts()) != 0 {
+		t.Fatalf("expected no scripts on the first environment, got %d", len(scripts.GetInitScripts()))
+	}
+}
+
+func mustCreateMcp(ctx context.Context, t *testing.T, server *Server, environmentID, name string) {
+	t.Helper()
+	if _, err := server.CreateMcp(ctx, &agentsv1.CreateMcpRequest{
+		EnvironmentId: environmentID, Name: name, Command: "run",
+	}); err != nil {
+		t.Fatalf("create mcp %s: %v", name, err)
+	}
+}
+
+func mustCreateVolume(ctx context.Context, t *testing.T, server *Server, environmentID, name, path string) {
+	t.Helper()
+	if _, err := server.CreateVolume(ctx, &agentsv1.CreateVolumeRequest{
+		Target:    &agentsv1.CreateVolumeRequest_EnvironmentId{EnvironmentId: environmentID},
+		Name:      name,
+		MountPath: path,
+	}); err != nil {
+		t.Fatalf("create volume %s: %v", name, err)
+	}
+}

--- a/internal/server/images.go
+++ b/internal/server/images.go
@@ -244,9 +244,12 @@ func (s *Server) applyMcpImageUpdate(
 		return nil
 	}
 
-	organizationID, err := s.organizationOfAgent(ctx, existing.AgentID)
-	if err != nil {
-		return err
+	organizationID := existing.OrganizationID
+	if existing.AgentID != nil {
+		organizationID, err = s.organizationOfAgent(ctx, *existing.AgentID)
+		if err != nil {
+			return err
+		}
 	}
 	if err := s.validateMcpImage(ctx, *reference, organizationID); err != nil {
 		return err

--- a/internal/server/list_authorization_test.go
+++ b/internal/server/list_authorization_test.go
@@ -42,16 +42,6 @@ func listRPCs() []listRPC {
 			},
 		},
 		{
-			name: "ListVolumes",
-			call: func(server *Server, ctx context.Context, organizationID string) error {
-				_, err := server.ListVolumes(ctx, &agentsv1.ListVolumesRequest{
-					OrganizationId: organizationID,
-					PageToken:      undecodablePageToken,
-				})
-				return err
-			},
-		},
-		{
 			name: "ListEnvironments",
 			call: func(server *Server, ctx context.Context, organizationID string) error {
 				_, err := server.ListEnvironments(ctx, &agentsv1.ListEnvironmentsRequest{

--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	agentUpdatedEvent   = "agent.updated"
-	sandboxUpdatedEvent = "sandbox.updated"
+	agentUpdatedEvent       = "agent.updated"
+	environmentUpdatedEvent = "environment.updated"
+	sandboxUpdatedEvent     = "sandbox.updated"
 )
 
 func (s *Server) publishAgentUpdated(ctx context.Context, agentID uuid.UUID, organizationID uuid.UUID) {
@@ -34,6 +35,37 @@ func (s *Server) publishAgentUpdated(ctx context.Context, agentID uuid.UUID, org
 	})
 	if err != nil {
 		log.Printf("agents: publish agent.updated: %v", err)
+	}
+}
+
+// publishEnvironmentUpdated announces a change to an environment or anything it
+// owns, on one room. Every agent and sandbox running the environment is
+// affected, so fanning this out per referencing agent would be the wrong shape.
+func (s *Server) publishEnvironmentUpdated(ctx context.Context, environmentID uuid.UUID, organizationID uuid.UUID) {
+	payload, err := structpb.NewStruct(map[string]any{
+		"environment_id":  environmentID.String(),
+		"organization_id": organizationID.String(),
+	})
+	if err != nil {
+		log.Printf("agents: build environment.updated payload: %v", err)
+		return
+	}
+	_, err = s.notifications.Publish(ctx, &notificationsv1.PublishRequest{
+		Event:   environmentUpdatedEvent,
+		Rooms:   []string{fmt.Sprintf("environment:%s", environmentID)},
+		Payload: payload,
+		Source:  "agents",
+	})
+	if err != nil {
+		log.Printf("agents: publish environment.updated: %v", err)
+	}
+}
+
+// publishVolumeTargetUpdated announces a volume write to whichever owner it
+// names.
+func (s *Server) publishVolumeTargetUpdated(ctx context.Context, volume store.Volume) {
+	if volume.EnvironmentID != nil {
+		s.publishEnvironmentUpdated(ctx, *volume.EnvironmentID, volume.OrganizationID)
 	}
 }
 
@@ -92,7 +124,10 @@ func (s *Server) resolveAgentID(ctx context.Context, agentID *uuid.UUID, mcpID *
 		if err != nil {
 			return uuid.UUID{}, err
 		}
-		return mcp.AgentID, nil
+		if mcp.AgentID == nil {
+			return uuid.UUID{}, fmt.Errorf("mcp %s targets an environment", mcp.Meta.ID)
+		}
+		return *mcp.AgentID, nil
 	}
 	return uuid.UUID{}, fmt.Errorf("missing target identifier")
 }
@@ -113,6 +148,12 @@ func (s *Server) publishAgentUpdatedForVolume(ctx context.Context, volumeID uuid
 // an environment belongs to an organization — and there is nothing to notify.
 func (s *Server) publishAgentUpdatedForConfigTarget(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, environmentID *uuid.UUID) {
 	if environmentID != nil {
+		environment, err := s.store.GetEnvironment(ctx, *environmentID)
+		if err != nil {
+			log.Printf("agents: fetch environment for notification: %v", err)
+			return
+		}
+		s.publishEnvironmentUpdated(ctx, environment.Meta.ID, environment.OrganizationID)
 		return
 	}
 	s.publishAgentUpdatedForTarget(ctx, agentID, mcpID)

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -206,9 +206,10 @@ func (s *Server) DeleteEnvironment(ctx context.Context, req *agentsv1.DeleteEnvi
 	if err := s.requireEnvironmentWrite(ctx, existing); err != nil {
 		return nil, err
 	}
-	// Role tuples are not enumerated here: the role API that would record them
-	// is not implemented yet, so the only one is the creator's owner tuple.
-	var roles []store.EnvironmentRoleAssignment
+	roles, err := s.store.ListEnvironmentRoles(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
 	if err := s.store.DeleteEnvironment(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -40,6 +40,13 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 	}
+	creatorID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrganizationRelation(ctx, creatorID, organizationID, "can_create_environment"); err != nil {
+		return nil, err
+	}
 	// Required, with no default: running in an environment reaches its secrets,
 	// so who may do so is the author's decision to state.
 	availability, err := environmentAvailabilityFromProto(req.GetAvailability())
@@ -95,6 +102,14 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	// The creator becomes the owner. A failure here would leave an environment
+	// nobody can reach, so the record is rolled back with it.
+	if err := s.addEnvironmentAuthorization(ctx, environment.Meta.ID, organizationID, creatorID, availability); err != nil {
+		if rollbackErr := s.store.DeleteEnvironment(ctx, environment.Meta.ID); rollbackErr != nil {
+			return nil, status.Errorf(codes.Internal, "authorization failed: %v; rollback failed: %v", err, rollbackErr)
+		}
+		return nil, err
+	}
 	return &agentsv1.CreateEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
 }
 
@@ -106,6 +121,9 @@ func (s *Server) GetEnvironment(ctx context.Context, req *agentsv1.GetEnvironmen
 	environment, err := s.store.GetEnvironment(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.requireEnvironmentRead(ctx, environment); err != nil {
+		return nil, err
 	}
 	return &agentsv1.GetEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
 }
@@ -119,6 +137,13 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 		req.WorkspaceImageId == nil && req.WorkspaceImageTag == nil &&
 		req.AgentRuntimeImageId == nil && req.AgentRuntimeImageTag == nil && req.Availability == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+	existing, err := s.store.GetEnvironment(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireEnvironmentWrite(ctx, existing); err != nil {
+		return nil, err
 	}
 	update := store.EnvironmentUpdate{}
 	if req.Name != nil {
@@ -160,6 +185,12 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if update.Availability != nil {
+		if err := s.updateEnvironmentAvailabilityAuthorization(ctx, environment.Meta.ID, environment.OrganizationID, existing.Availability, *update.Availability); err != nil {
+			return nil, err
+		}
+	}
+	s.publishEnvironmentUpdated(ctx, environment.Meta.ID, environment.OrganizationID)
 	return &agentsv1.UpdateEnvironmentResponse{Environment: toProtoEnvironment(environment)}, nil
 }
 
@@ -168,8 +199,21 @@ func (s *Server) DeleteEnvironment(ctx context.Context, req *agentsv1.DeleteEnvi
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
+	existing, err := s.store.GetEnvironment(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireEnvironmentWrite(ctx, existing); err != nil {
+		return nil, err
+	}
+	// Role tuples are not enumerated here: the role API that would record them
+	// is not implemented yet, so the only one is the creator's owner tuple.
+	var roles []store.EnvironmentRoleAssignment
 	if err := s.store.DeleteEnvironment(ctx, id); err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.removeEnvironmentAuthorization(ctx, id, existing.OrganizationID, roles, existing.Availability); err != nil {
+		return nil, err
 	}
 	return &agentsv1.DeleteEnvironmentResponse{}, nil
 }
@@ -222,6 +266,9 @@ func (s *Server) CreateSandbox(ctx context.Context, req *agentsv1.CreateSandboxR
 		return nil, err
 	}
 	if err := s.requireOrganizationRelation(ctx, ownerID, organizationID, "can_create_sandbox"); err != nil {
+		return nil, err
+	}
+	if err := s.requireEnvironmentUse(ctx, environmentID); err != nil {
 		return nil, err
 	}
 

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -40,6 +40,12 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
 	}
+	// Required, with no default: running in an environment reaches its secrets,
+	// so who may do so is the author's decision to state.
+	availability, err := environmentAvailabilityFromProto(req.GetAvailability())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "availability: %v", err)
+	}
 	if err := validateSandboxName(req.GetName()); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
 	}
@@ -71,10 +77,11 @@ func (s *Server) CreateEnvironment(ctx context.Context, req *agentsv1.CreateEnvi
 	// it is resolved at workload start so an environment and the runner
 	// configuration naming its flavor can be applied in either order.
 	input := store.EnvironmentInput{
-		Name:     req.GetName(),
-		Image:    req.GetImage(),
-		RunnerID: &runnerID,
-		Flavor:   req.GetFlavor(),
+		Availability: availability,
+		Name:         req.GetName(),
+		Image:        req.GetImage(),
+		RunnerID:     &runnerID,
+		Flavor:       req.GetFlavor(),
 	}
 	if workspace != nil {
 		input.WorkspaceImageID = &workspace.ImageID
@@ -110,7 +117,7 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 	}
 	if req.Name == nil && req.Image == nil && req.RunnerId == nil && req.Flavor == nil &&
 		req.WorkspaceImageId == nil && req.WorkspaceImageTag == nil &&
-		req.AgentRuntimeImageId == nil && req.AgentRuntimeImageTag == nil {
+		req.AgentRuntimeImageId == nil && req.AgentRuntimeImageTag == nil && req.Availability == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 	update := store.EnvironmentUpdate{}
@@ -131,6 +138,13 @@ func (s *Server) UpdateEnvironment(ctx context.Context, req *agentsv1.UpdateEnvi
 	if req.Flavor != nil {
 		flavor := req.GetFlavor()
 		update.Flavor = &flavor
+	}
+	if req.Availability != nil {
+		availability, err := environmentAvailabilityFromProto(req.GetAvailability())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "availability: %v", err)
+		}
+		update.Availability = &availability
 	}
 	if err := s.applyEnvironmentImageUpdate(ctx, req, id, &update); err != nil {
 		return nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -139,6 +139,12 @@ func (s *Server) environmentInOrganization(ctx context.Context, value string, or
 	if environment.OrganizationID != organizationID {
 		return uuid.UUID{}, status.Error(codes.InvalidArgument, "environment_id: environment belongs to another organization")
 	}
+	// Pointing an agent at an environment runs its workloads there, reaching the
+	// same secrets, egress credentials and volume contents a sandbox would, so
+	// it takes the same grant.
+	if err := s.requireEnvironmentUse(ctx, environmentID); err != nil {
+		return uuid.UUID{}, err
+	}
 	return environmentID, nil
 }
 
@@ -858,7 +864,7 @@ func (s *Server) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesReque
 		if err != nil {
 			return nil, toStatusError(err)
 		}
-		if err := s.requireEnvironmentRead(ctx, environment); err != nil {
+		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
 			return nil, err
 		}
 		filter.EnvironmentID = &environmentID
@@ -1030,14 +1036,26 @@ func (s *Server) ListMcps(ctx context.Context, req *agentsv1.ListMcpsRequest) (*
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
 
-	if req.GetAgentId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "agent_id must be provided")
+	filter := store.McpFilter{}
+	switch {
+	case req.GetEnvironmentId() != "":
+		environmentID, err := parseUUID(req.GetEnvironmentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+			return nil, err
+		}
+		filter.EnvironmentID = &environmentID
+	case req.GetAgentId() != "":
+		agentID, err := parseUUID(req.GetAgentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+		}
+		filter.AgentID = &agentID
+	default:
+		return nil, status.Error(codes.InvalidArgument, "agent_id or environment_id must be provided")
 	}
-	agentID, err := parseUUID(req.GetAgentId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
-	}
-	filter := store.McpFilter{AgentID: &agentID}
 
 	result, err := s.store.ListMcps(ctx, filter, req.GetPageSize(), cursor)
 	if err != nil {
@@ -1315,6 +1333,9 @@ func (s *Server) envListFilter(ctx context.Context, req *agentsv1.ListEnvsReques
 		if err != nil {
 			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 		}
+		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+			return store.EnvFilter{}, err
+		}
 		filter.EnvironmentID = &environmentID
 	}
 
@@ -1444,6 +1465,16 @@ func (s *Server) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScri
 
 	hasFilter := false
 	filter := store.InitScriptFilter{}
+	if req.GetEnvironmentId() != "" {
+		environmentID, err := parseUUID(req.GetEnvironmentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+			return nil, err
+		}
+		filter.EnvironmentID = &environmentID
+	}
 	if req.GetAgentId() != "" {
 		hasFilter = true
 		agentID, err := parseUUID(req.GetAgentId())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -687,22 +687,70 @@ func (s *Server) ListAgents(ctx context.Context, req *agentsv1.ListAgentsRequest
 	return &agentsv1.ListAgentsResponse{Agents: agents, NextPageToken: nextToken}, nil
 }
 
-func (s *Server) CreateVolume(ctx context.Context, req *agentsv1.CreateVolumeRequest) (*agentsv1.CreateVolumeResponse, error) {
-	organizationID, err := parseUUID(req.GetOrganizationId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+// volumeTarget resolves the environment or MCP a volume names, and the
+// organization both belong to. Authorization follows the target: a volume is
+// gated by the environment that owns it, never by itself.
+func (s *Server) volumeTarget(ctx context.Context, environmentIDRaw, mcpIDRaw string) (store.VolumeInput, uuid.UUID, error) {
+	input := store.VolumeInput{}
+	switch {
+	case environmentIDRaw != "":
+		environmentID, err := parseUUID(environmentIDRaw)
+		if err != nil {
+			return input, uuid.UUID{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		environment, err := s.store.GetEnvironment(ctx, environmentID)
+		if err != nil {
+			return input, uuid.UUID{}, toStatusError(err)
+		}
+		if err := s.requireEnvironmentWrite(ctx, environment); err != nil {
+			return input, uuid.UUID{}, err
+		}
+		input.EnvironmentID = &environmentID
+		return input, environment.OrganizationID, nil
+	case mcpIDRaw != "":
+		mcpID, err := parseUUID(mcpIDRaw)
+		if err != nil {
+			return input, uuid.UUID{}, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		mcp, err := s.store.GetMcp(ctx, mcpID)
+		if err != nil {
+			return input, uuid.UUID{}, toStatusError(err)
+		}
+		input.McpID = &mcpID
+		return input, mcp.OrganizationID, nil
+	default:
+		return input, uuid.UUID{}, status.Error(codes.InvalidArgument, "environment_id or mcp_id is required")
 	}
-	volume, err := s.store.CreateVolume(ctx, organizationID, store.VolumeInput{
-		Persistent:  req.GetPersistent(),
-		MountPath:   req.GetMountPath(),
-		Size:        req.GetSize(),
-		Description: req.GetDescription(),
-		TTL:         req.Ttl,
-	})
+}
+
+func (s *Server) CreateVolume(ctx context.Context, req *agentsv1.CreateVolumeRequest) (*agentsv1.CreateVolumeResponse, error) {
+	input, organizationID, err := s.volumeTarget(ctx, req.GetEnvironmentId(), req.GetMcpId())
+	if err != nil {
+		return nil, err
+	}
+	if err := validateVolumeName(req.GetName()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+	}
+	if err := validateMountPath(req.GetMountPath()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "mount_path: %v", err)
+	}
+	// size is what makes a volume persistent: the two are biconditional, so a
+	// separate flag could only ever contradict it.
+	size, persistent, err := resolveVolumeSize(req.GetSize(), req.GetPersistent())
+	if err != nil {
+		return nil, err
+	}
+	input.Name = req.GetName()
+	input.MountPath = req.GetMountPath()
+	input.Persistent = persistent
+	input.Size = size
+	input.StorageClass = req.StorageClass
+	input.TTL = req.Ttl
+	volume, err := s.store.CreateVolume(ctx, organizationID, input)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForVolume(ctx, volume.Meta.ID)
+	s.publishVolumeTargetUpdated(ctx, volume)
 	return &agentsv1.CreateVolumeResponse{Volume: toProtoVolume(volume)}, nil
 }
 
@@ -723,29 +771,51 @@ func (s *Server) UpdateVolume(ctx context.Context, req *agentsv1.UpdateVolumeReq
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	if req.Persistent == nil && req.MountPath == nil && req.Size == nil && req.Description == nil && req.Ttl == nil {
+	if req.Persistent == nil && req.MountPath == nil && req.Size == nil &&
+		req.Name == nil && req.StorageClass == nil && req.Ttl == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+	existing, err := s.store.GetVolume(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireVolumeWrite(ctx, existing); err != nil {
+		return nil, err
 	}
 
 	update := store.VolumeUpdate{}
-	if req.Persistent != nil {
-		value := req.GetPersistent()
-		update.Persistent = &value
+	if req.Name != nil {
+		value := req.GetName()
+		if err := validateVolumeName(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+		}
+		update.Name = &value
 	}
 	if req.MountPath != nil {
 		value := req.GetMountPath()
+		if err := validateMountPath(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "mount_path: %v", err)
+		}
 		update.MountPath = &value
 	}
-	if req.Size != nil {
-		value := req.GetSize()
-		update.Size = &value
+	if req.Size != nil || req.Persistent != nil {
+		requestedSize := req.GetSize()
+		if req.Size == nil && existing.Size != nil {
+			requestedSize = *existing.Size
+		}
+		size, persistent, err := resolveVolumeSize(requestedSize, req.GetPersistent())
+		if err != nil {
+			return nil, err
+		}
+		update.Size = &size
+		update.Persistent = &persistent
 	}
-	if req.Description != nil {
-		value := req.GetDescription()
-		update.Description = &value
+	if req.StorageClass != nil {
+		value := req.StorageClass
+		update.StorageClass = &value
 	}
 	if req.Ttl != nil {
-		value := req.GetTtl()
+		value := req.Ttl
 		update.TTL = &value
 	}
 
@@ -753,7 +823,7 @@ func (s *Server) UpdateVolume(ctx context.Context, req *agentsv1.UpdateVolumeReq
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForVolume(ctx, volume.Meta.ID)
+	s.publishVolumeTargetUpdated(ctx, volume)
 	return &agentsv1.UpdateVolumeResponse{Volume: toProtoVolume(volume)}, nil
 }
 
@@ -776,18 +846,42 @@ func (s *Server) DeleteVolume(ctx context.Context, req *agentsv1.DeleteVolumeReq
 }
 
 func (s *Server) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesRequest) (*agentsv1.ListVolumesResponse, error) {
-	organizationID, err := parseUUID(req.GetOrganizationId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-	}
-	if err := s.requireOrganizationListAccess(ctx, organizationID); err != nil {
-		return nil, err
+	filter := store.VolumeFilter{}
+	var organizationID uuid.UUID
+	switch {
+	case req.GetEnvironmentId() != "":
+		environmentID, err := parseUUID(req.GetEnvironmentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		environment, err := s.store.GetEnvironment(ctx, environmentID)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		if err := s.requireEnvironmentRead(ctx, environment); err != nil {
+			return nil, err
+		}
+		filter.EnvironmentID = &environmentID
+		organizationID = environment.OrganizationID
+	case req.GetMcpId() != "":
+		mcpID, err := parseUUID(req.GetMcpId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		mcp, err := s.store.GetMcp(ctx, mcpID)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		filter.McpID = &mcpID
+		organizationID = mcp.OrganizationID
+	default:
+		return nil, status.Error(codes.InvalidArgument, "environment_id or mcp_id is required")
 	}
 	cursor, err := decodePageCursor(req.GetPageToken())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
-	result, err := s.store.ListVolumes(ctx, organizationID, store.VolumeFilter{}, req.GetPageSize(), cursor)
+	result, err := s.store.ListVolumes(ctx, organizationID, filter, req.GetPageSize(), cursor)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
@@ -795,153 +889,71 @@ func (s *Server) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesReque
 	return &agentsv1.ListVolumesResponse{Volumes: volumes, NextPageToken: nextToken}, nil
 }
 
-func (s *Server) CreateVolumeAttachment(ctx context.Context, req *agentsv1.CreateVolumeAttachmentRequest) (*agentsv1.CreateVolumeAttachmentResponse, error) {
-	volumeID, err := parseUUID(req.GetVolumeId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "volume_id: %v", err)
+func (s *Server) CreateMcp(ctx context.Context, req *agentsv1.CreateMcpRequest) (*agentsv1.CreateMcpResponse, error) {
+	name := req.GetName()
+	if err := validateMcpName(name); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
 	}
-
-	input := store.VolumeAttachmentInput{VolumeID: volumeID}
-	switch target := req.GetTarget().(type) {
-	case *agentsv1.CreateVolumeAttachmentRequest_AgentId:
-		id, err := parseUUID(target.AgentId)
+	input := store.McpInput{
+		Name:          name,
+		Image:         req.GetImage(),
+		Command:       req.GetCommand(),
+		Resources:     toStoreComputeResources(req.GetResources()),
+		Description:   req.GetDescription(),
+		SharedVolumes: req.GetSharedVolumes(),
+	}
+	var organizationID uuid.UUID
+	switch {
+	case req.GetEnvironmentId() != "":
+		environmentID, err := parseUUID(req.GetEnvironmentId())
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 		}
-		input.AgentID = &id
-	case *agentsv1.CreateVolumeAttachmentRequest_McpId:
-		id, err := parseUUID(target.McpId)
+		environment, err := s.store.GetEnvironment(ctx, environmentID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+			return nil, toStatusError(err)
 		}
-		input.McpID = &id
-	default:
-		return nil, status.Error(codes.InvalidArgument, "target must be specified")
-	}
-
-	attachment, err := s.store.CreateVolumeAttachment(ctx, input)
-	if err != nil {
-		return nil, toStatusError(err)
-	}
-	s.publishAgentUpdatedForTarget(ctx, attachment.AgentID, attachment.McpID)
-	return &agentsv1.CreateVolumeAttachmentResponse{VolumeAttachment: toProtoVolumeAttachment(attachment)}, nil
-}
-
-func (s *Server) GetVolumeAttachment(ctx context.Context, req *agentsv1.GetVolumeAttachmentRequest) (*agentsv1.GetVolumeAttachmentResponse, error) {
-	id, err := parseUUID(req.GetId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
-	}
-	attachment, err := s.store.GetVolumeAttachment(ctx, id)
-	if err != nil {
-		return nil, toStatusError(err)
-	}
-	return &agentsv1.GetVolumeAttachmentResponse{VolumeAttachment: toProtoVolumeAttachment(attachment)}, nil
-}
-
-func (s *Server) DeleteVolumeAttachment(ctx context.Context, req *agentsv1.DeleteVolumeAttachmentRequest) (*agentsv1.DeleteVolumeAttachmentResponse, error) {
-	id, err := parseUUID(req.GetId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
-	}
-	attachment, err := s.store.GetVolumeAttachment(ctx, id)
-	if err != nil {
-		return nil, toStatusError(err)
-	}
-	if err := s.store.DeleteVolumeAttachment(ctx, id); err != nil {
-		return nil, toStatusError(err)
-	}
-	s.publishAgentUpdatedForTarget(ctx, attachment.AgentID, attachment.McpID)
-	return &agentsv1.DeleteVolumeAttachmentResponse{}, nil
-}
-
-func (s *Server) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
-	cursor, err := decodePageCursor(req.GetPageToken())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
-	}
-
-	hasFilter := false
-	filter := store.VolumeAttachmentFilter{}
-	if req.GetVolumeId() != "" {
-		hasFilter = true
-		volumeID, err := parseUUID(req.GetVolumeId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "volume_id: %v", err)
+		if err := s.requireEnvironmentWrite(ctx, environment); err != nil {
+			return nil, err
 		}
-		filter.VolumeID = &volumeID
-	}
-	if req.GetAgentId() != "" {
-		hasFilter = true
+		input.EnvironmentID = &environmentID
+		organizationID = environment.OrganizationID
+	case req.GetAgentId() != "":
 		agentID, err := parseUUID(req.GetAgentId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 		}
-		filter.AgentID = &agentID
-	}
-	if req.GetMcpId() != "" {
-		hasFilter = true
-		mcpID, err := parseUUID(req.GetMcpId())
+		organizationID, err = s.organizationOfAgent(ctx, agentID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+			return nil, err
 		}
-		filter.McpID = &mcpID
+		input.AgentID = &agentID
+	default:
+		return nil, status.Error(codes.InvalidArgument, "environment_id or agent_id is required")
 	}
-	if !hasFilter {
-		return nil, status.Error(codes.InvalidArgument, "at least one filter must be provided")
-	}
-
-	result, err := s.store.ListVolumeAttachments(ctx, filter, req.GetPageSize(), cursor)
-	if err != nil {
-		return nil, toStatusError(err)
-	}
-	attachments, nextToken := mapListResult(result.VolumeAttachments, result.NextCursor, toProtoVolumeAttachment)
-	return &agentsv1.ListVolumeAttachmentsResponse{VolumeAttachments: attachments, NextPageToken: nextToken}, nil
-}
-
-func (s *Server) CreateMcp(ctx context.Context, req *agentsv1.CreateMcpRequest) (*agentsv1.CreateMcpResponse, error) {
-	agentID, err := parseUUID(req.GetAgentId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
-	}
-	name := req.GetName()
-	if err := validateMcpName(name); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+	// shared_volumes names environment volumes, which an MCP on an environment
+	// resolves against its own; an agent-level one resolves at workload start.
+	if len(input.SharedVolumes) > 0 && input.AgentID == nil && input.EnvironmentID == nil {
+		return nil, status.Error(codes.InvalidArgument, "shared_volumes requires a target")
 	}
 	reference, err := parseImageReference(req.GetImageId(), req.GetImageTag(), "image")
 	if err != nil {
 		return nil, err
 	}
 	if reference != nil {
-		organizationID, err := s.organizationOfAgent(ctx, agentID)
-		if err != nil {
-			return nil, err
-		}
 		// An MCP may run a purpose-built server image or a devcontainer, so
 		// the type is not narrowed here; the catalog rejects an agent runtime.
 		if err := s.validateMcpImage(ctx, *reference, organizationID); err != nil {
 			return nil, err
 		}
-	}
-
-	resources := toStoreComputeResources(req.GetResources())
-	input := store.McpInput{
-		AgentID:     agentID,
-		Name:        name,
-		Image:       req.GetImage(),
-		Command:     req.GetCommand(),
-		Resources:   resources,
-		Description: req.GetDescription(),
-	}
-	if reference != nil {
 		input.ImageID = &reference.ImageID
 		input.ImageTag = reference.Tag
 	}
-	mcp, err := s.store.CreateMcp(ctx, input)
+	mcp, err := s.store.CreateMcp(ctx, organizationID, input)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedByID(ctx, mcp.AgentID)
+	s.publishAgentUpdatedForConfigTarget(ctx, mcp.AgentID, nil, mcp.EnvironmentID)
 	return &agentsv1.CreateMcpResponse{Mcp: toProtoMcp(mcp)}, nil
 }
 
@@ -992,7 +1004,7 @@ func (s *Server) UpdateMcp(ctx context.Context, req *agentsv1.UpdateMcpRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedByID(ctx, mcp.AgentID)
+	s.publishAgentUpdatedForConfigTarget(ctx, mcp.AgentID, nil, mcp.EnvironmentID)
 	return &agentsv1.UpdateMcpResponse{Mcp: toProtoMcp(mcp)}, nil
 }
 
@@ -1008,7 +1020,7 @@ func (s *Server) DeleteMcp(ctx context.Context, req *agentsv1.DeleteMcpRequest) 
 	if err := s.store.DeleteMcp(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedByID(ctx, mcp.AgentID)
+	s.publishAgentUpdatedForConfigTarget(ctx, mcp.AgentID, nil, mcp.EnvironmentID)
 	return &agentsv1.DeleteMcpResponse{}, nil
 }
 
@@ -1319,6 +1331,7 @@ func (s *Server) CreateInitScript(ctx context.Context, req *agentsv1.CreateInitS
 		Script:      req.GetScript(),
 		Description: req.GetDescription(),
 	}
+	var organizationID uuid.UUID
 
 	switch target := req.GetTarget().(type) {
 	case *agentsv1.CreateInitScriptRequest_AgentId:
@@ -1326,22 +1339,45 @@ func (s *Server) CreateInitScript(ctx context.Context, req *agentsv1.CreateInitS
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 		}
+		organizationID, err = s.organizationOfAgent(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 		input.AgentID = &id
 	case *agentsv1.CreateInitScriptRequest_McpId:
 		id, err := parseUUID(target.McpId)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
 		}
+		mcp, err := s.store.GetMcp(ctx, id)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		organizationID = mcp.OrganizationID
 		input.McpID = &id
+	case *agentsv1.CreateInitScriptRequest_EnvironmentId:
+		id, err := parseUUID(target.EnvironmentId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		}
+		environment, err := s.store.GetEnvironment(ctx, id)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		if err := s.requireEnvironmentWrite(ctx, environment); err != nil {
+			return nil, err
+		}
+		organizationID = environment.OrganizationID
+		input.EnvironmentID = &id
 	default:
 		return nil, status.Error(codes.InvalidArgument, "target must be specified")
 	}
 
-	script, err := s.store.CreateInitScript(ctx, input)
+	script, err := s.store.CreateInitScript(ctx, organizationID, input)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, script.AgentID, script.McpID)
+	s.publishAgentUpdatedForConfigTarget(ctx, script.AgentID, script.McpID, script.EnvironmentID)
 	return &agentsv1.CreateInitScriptResponse{InitScript: toProtoInitScript(script)}, nil
 }
 
@@ -1528,6 +1564,26 @@ func toStoreComputeResources(resources *agentsv1.ComputeResources) store.Compute
 		LimitsCPU:      resources.GetLimitsCpu(),
 		LimitsMemory:   resources.GetLimitsMemory(),
 	}
+}
+
+func environmentAvailabilityFromProto(availability agentsv1.EnvironmentAvailability) (store.EnvironmentAvailability, error) {
+	switch availability {
+	case agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL:
+		return store.EnvironmentAvailabilityInternal, nil
+	case agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE:
+		return store.EnvironmentAvailabilityPrivate, nil
+	case agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_UNSPECIFIED:
+		return "", fmt.Errorf("must be internal or private")
+	default:
+		return "", fmt.Errorf("unknown value %d", availability)
+	}
+}
+
+func toProtoEnvironmentAvailability(availability store.EnvironmentAvailability) agentsv1.EnvironmentAvailability {
+	if availability == store.EnvironmentAvailabilityPrivate {
+		return agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_PRIVATE
+	}
+	return agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL
 }
 
 func agentAvailabilityFromProto(availability agentsv1.AgentAvailability) (store.AgentAvailability, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1474,6 +1474,7 @@ func (s *Server) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScri
 			return nil, err
 		}
 		filter.EnvironmentID = &environmentID
+		hasFilter = true
 	}
 	if req.GetAgentId() != "" {
 		hasFilter = true

--- a/internal/server/volume_attachment_compat_test.go
+++ b/internal/server/volume_attachment_compat_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/google/uuid"
+)
+
+// Orchestrators released before this change list an agent's volumes as
+// attachments and mount whatever comes back. Serving them the environment's
+// volumes keeps that path correct while the two services are on different
+// versions; returning nothing would silently start agents without their disks.
+func TestListVolumeAttachmentsServesTheEnvironmentsVolumes(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
+
+	environmentID := createTestEnvironment(ctx, t, server, organizationID, "shared")
+	mustCreateVolume(ctx, t, server, environmentID, "data", "/data")
+
+	request := createAgentRequest(organizationID, "alpha")
+	request.EnvironmentId = environmentID
+	created, err := server.CreateAgent(ctx, request)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agentID := created.GetAgent().GetMeta().GetId()
+
+	listed, err := server.ListVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{AgentId: agentID})
+	if err != nil {
+		t.Fatalf("list volume attachments: %v", err)
+	}
+	attachments := listed.GetVolumeAttachments()
+	if len(attachments) != 1 {
+		t.Fatalf("expected the environment's one volume, got %d", len(attachments))
+	}
+	if attachments[0].GetAgentId() != agentID {
+		t.Fatalf("expected the attachment targeted at %s, got %q", agentID, attachments[0].GetAgentId())
+	}
+
+	// The caller resolves the mount path through GetVolume, so the id has to
+	// be the real one rather than a synthesised attachment id.
+	volume, err := server.GetVolume(ctx, &agentsv1.GetVolumeRequest{Id: attachments[0].GetVolumeId()})
+	if err != nil {
+		t.Fatalf("get volume: %v", err)
+	}
+	if volume.GetVolume().GetMountPath() != "/data" {
+		t.Fatalf("expected /data, got %q", volume.GetVolume().GetMountPath())
+	}
+}
+
+// An agent in no environment has no volumes, which is an empty list rather than
+// an error: the old orchestrator treats a failure here as an unassemblable
+// agent.
+func TestListVolumeAttachmentsForAnAgentWithoutAnEnvironment(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+
+	created, err := server.CreateAgent(ctx, createAgentRequest(uuid.New(), "alpha"))
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	listed, err := server.ListVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{
+		AgentId: created.GetAgent().GetMeta().GetId(),
+	})
+	if err != nil {
+		t.Fatalf("list volume attachments: %v", err)
+	}
+	if len(listed.GetVolumeAttachments()) != 0 {
+		t.Fatalf("expected no attachments, got %d", len(listed.GetVolumeAttachments()))
+	}
+}
+
+func TestListVolumeAttachmentsRequiresATarget(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+
+	if _, err := server.ListVolumeAttachments(ctx, &agentsv1.ListVolumeAttachmentsRequest{}); err == nil {
+		t.Fatal("expected an unfiltered listing to be refused")
+	}
+}

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/agynio/agents/internal/store"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const maxVolumeNameLength = 64
+
+var volumeNamePattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+func validateVolumeName(name string) error {
+	if name == "" {
+		return fmt.Errorf("value is empty")
+	}
+	if len(name) > maxVolumeNameLength {
+		return fmt.Errorf("must be at most %d characters", maxVolumeNameLength)
+	}
+	if !volumeNamePattern.MatchString(name) {
+		return fmt.Errorf("must match %s", volumeNamePattern.String())
+	}
+	return nil
+}
+
+func validateMountPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("value is empty")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("must be an absolute path")
+	}
+	return nil
+}
+
+// resolveVolumeSize settles persistence from the size, which the resource makes
+// biconditional: a size means a provisioned disk, no size means scratch. A
+// caller asking for persistence without a size is asking for a disk of no
+// stated capacity, which is refused rather than defaulted.
+func resolveVolumeSize(size string, persistent bool) (*string, bool, error) {
+	trimmed := strings.TrimSpace(size)
+	if trimmed == "" {
+		if persistent {
+			return nil, false, status.Error(codes.InvalidArgument, "size is required for a persistent volume")
+		}
+		return nil, false, nil
+	}
+	return &trimmed, true, nil
+}
+
+// requireVolumeWrite authorizes changing a volume through the target that owns
+// it. A volume carries no tuples of its own.
+func (s *Server) requireVolumeWrite(ctx context.Context, volume store.Volume) error {
+	if volume.EnvironmentID != nil {
+		environment, err := s.store.GetEnvironment(ctx, *volume.EnvironmentID)
+		if err != nil {
+			return toStatusError(err)
+		}
+		return s.requireEnvironmentWrite(ctx, environment)
+	}
+	return nil
+}

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -6,7 +6,9 @@ import (
 	"regexp"
 	"strings"
 
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
 	"github.com/agynio/agents/internal/store"
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -64,4 +66,85 @@ func (s *Server) requireVolumeWrite(ctx context.Context, volume store.Volume) er
 		return s.requireEnvironmentWrite(ctx, environment)
 	}
 	return nil
+}
+
+// ListVolumeAttachments serves orchestrators released before volumes moved onto
+// environments. An agent's attachments are its environment's volumes and an
+// MCP's are its own, so an old orchestrator mounts the same volumes a new one
+// would. Without it, upgrading this service first leaves every agent assembly
+// failing on a missing RPC.
+func (s *Server) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+	switch {
+	case req.GetAgentId() != "":
+		agentID, err := parseUUID(req.GetAgentId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+		}
+		agent, err := s.store.GetAgent(ctx, agentID)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		if agent.EnvironmentID == nil {
+			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
+		}
+		volumes, err := s.environmentVolumes(ctx, *agent.EnvironmentID)
+		if err != nil {
+			return nil, err
+		}
+		return &agentsv1.ListVolumeAttachmentsResponse{
+			VolumeAttachments: attachmentsFor(volumes, func(a *agentsv1.VolumeAttachment) {
+				a.Target = &agentsv1.VolumeAttachment_AgentId{AgentId: agentID.String()}
+			}),
+		}, nil
+	case req.GetMcpId() != "":
+		mcpID, err := parseUUID(req.GetMcpId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		mcp, err := s.store.GetMcp(ctx, mcpID)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		result, err := s.store.ListVolumes(ctx, mcp.OrganizationID, store.VolumeFilter{McpID: &mcpID}, 0, nil)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		return &agentsv1.ListVolumeAttachmentsResponse{
+			VolumeAttachments: attachmentsFor(result.Volumes, func(a *agentsv1.VolumeAttachment) {
+				a.Target = &agentsv1.VolumeAttachment_McpId{McpId: mcpID.String()}
+			}),
+		}, nil
+	default:
+		return nil, status.Error(codes.InvalidArgument, "agent_id or mcp_id is required")
+	}
+}
+
+func (s *Server) environmentVolumes(ctx context.Context, environmentID uuid.UUID) ([]store.Volume, error) {
+	environment, err := s.store.GetEnvironment(ctx, environmentID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+		return nil, err
+	}
+	result, err := s.store.ListVolumes(ctx, environment.OrganizationID, store.VolumeFilter{EnvironmentID: &environmentID}, 0, nil)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return result.Volumes, nil
+}
+
+// The attachment id is the volume's: nothing persists these any more, and a
+// caller correlating one back to a volume gets the id it already knows.
+func attachmentsFor(volumes []store.Volume, target func(*agentsv1.VolumeAttachment)) []*agentsv1.VolumeAttachment {
+	attachments := make([]*agentsv1.VolumeAttachment, 0, len(volumes))
+	for _, volume := range volumes {
+		attachment := &agentsv1.VolumeAttachment{
+			Meta:     toProtoEntityMeta(volume.Meta),
+			VolumeId: volume.Meta.ID.String(),
+		}
+		target(attachment)
+		attachments = append(attachments, attachment)
+	}
+	return attachments
 }

--- a/internal/store/agent_helpers.go
+++ b/internal/store/agent_helpers.go
@@ -24,6 +24,30 @@ func touchAgentUpdatedAt(ctx context.Context, tx pgx.Tx, agentID uuid.UUID) erro
 	return nil
 }
 
+// touchEnvironmentUpdatedAt propagates a sub-resource write to its environment,
+// which is what the Orchestrator's start decision compares against.
+func touchEnvironmentUpdatedAt(ctx context.Context, tx pgx.Tx, environmentID uuid.UUID) error {
+	result, err := tx.Exec(ctx, "UPDATE environments SET updated_at = NOW() WHERE id = $1", environmentID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return NotFound("environment")
+	}
+	return nil
+}
+
+// touchTargetUpdatedAt touches whichever owner a sub-resource names.
+func touchTargetUpdatedAt(ctx context.Context, tx pgx.Tx, agentID *uuid.UUID, environmentID *uuid.UUID) error {
+	if agentID != nil {
+		return touchAgentUpdatedAt(ctx, tx, *agentID)
+	}
+	if environmentID != nil {
+		return touchEnvironmentUpdatedAt(ctx, tx, *environmentID)
+	}
+	return nil
+}
+
 func touchAgentsUpdatedAt(ctx context.Context, tx pgx.Tx, agentIDs []uuid.UUID) error {
 	for _, agentID := range agentIDs {
 		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {

--- a/internal/store/environment_roles.go
+++ b/internal/store/environment_roles.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Role storage mirrors agents: a row per grant, with the OpenFGA tuple written
+// alongside it by the service.
+func (s *Store) UpsertEnvironmentRole(ctx context.Context, assignment EnvironmentRoleAssignment) (*EnvironmentRole, error) {
+	var previous EnvironmentRole
+	err := s.pool.QueryRow(ctx,
+		`SELECT role FROM environment_roles WHERE environment_id = $1 AND identity_id = $2`,
+		assignment.EnvironmentID, assignment.IdentityID,
+	).Scan(&previous)
+	hadPrevious := true
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return nil, err
+		}
+		hadPrevious = false
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO environment_roles (environment_id, identity_id, role)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (environment_id, identity_id)
+		 DO UPDATE SET role = EXCLUDED.role, updated_at = NOW()`,
+		assignment.EnvironmentID, assignment.IdentityID, assignment.Role,
+	); err != nil {
+		return nil, err
+	}
+	if !hadPrevious {
+		return nil, nil
+	}
+	return &previous, nil
+}
+
+func (s *Store) DeleteEnvironmentRole(ctx context.Context, environmentID, identityID uuid.UUID) (EnvironmentRole, error) {
+	var role EnvironmentRole
+	err := s.pool.QueryRow(ctx,
+		`DELETE FROM environment_roles WHERE environment_id = $1 AND identity_id = $2 RETURNING role`,
+		environmentID, identityID,
+	).Scan(&role)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", NotFound("environment role")
+		}
+		return "", err
+	}
+	return role, nil
+}
+
+func (s *Store) ListEnvironmentRoles(ctx context.Context, environmentID uuid.UUID) ([]EnvironmentRoleAssignment, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT environment_id, identity_id, role FROM environment_roles WHERE environment_id = $1 ORDER BY identity_id ASC`,
+		environmentID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var assignments []EnvironmentRoleAssignment
+	for rows.Next() {
+		var assignment EnvironmentRoleAssignment
+		if err := rows.Scan(&assignment.EnvironmentID, &assignment.IdentityID, &assignment.Role); err != nil {
+			return nil, err
+		}
+		assignments = append(assignments, assignment)
+	}
+	return assignments, rows.Err()
+}

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -14,8 +14,8 @@ func (s *Store) CreateEnvironment(ctx context.Context, organizationID uuid.UUID,
 	row := s.pool.QueryRow(ctx,
 		fmt.Sprintf(`INSERT INTO environments
 		 (organization_id, name, image, runner_id, flavor,
-		  workspace_image_id, workspace_image_tag, agent_runtime_image_id, agent_runtime_image_tag)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		  workspace_image_id, workspace_image_tag, agent_runtime_image_id, agent_runtime_image_tag, availability)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		 RETURNING %s`, environmentColumns),
 		organizationID,
 		input.Name,
@@ -26,6 +26,7 @@ func (s *Store) CreateEnvironment(ctx context.Context, organizationID uuid.UUID,
 		input.WorkspaceImageTag,
 		input.AgentRuntimeImageID,
 		input.AgentRuntimeImageTag,
+		input.Availability,
 	)
 	environment, err := scanEnvironment(row)
 	if err != nil {
@@ -57,6 +58,9 @@ func (s *Store) UpdateEnvironment(ctx context.Context, id uuid.UUID, update Envi
 	builder := updateBuilder{}
 	if update.Name != nil {
 		builder.add("name", *update.Name)
+	}
+	if update.Availability != nil {
+		builder.add("availability", string(*update.Availability))
 	}
 	if update.Image != nil {
 		builder.add("image", *update.Image)

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -118,6 +118,24 @@ func (s *Store) DeleteEnvironment(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// ListAllEnvironments pages every environment regardless of organization. Used
+// by the authorization backfill, which repairs rows across all of them.
+func (s *Store) ListAllEnvironments(ctx context.Context, pageSize int32, cursor *PageCursor) (EnvironmentListResult, error) {
+	environments, nextCursor, err := listEntities(ctx, s.pool,
+		fmt.Sprintf("SELECT %s FROM environments", environmentColumns),
+		nil,
+		nil,
+		cursor,
+		pageSize,
+		scanEnvironment,
+		func(environment Environment) uuid.UUID { return environment.Meta.ID },
+	)
+	if err != nil {
+		return EnvironmentListResult{}, err
+	}
+	return EnvironmentListResult{Environments: environments, NextCursor: nextCursor}, nil
+}
+
 func (s *Store) ListEnvironments(ctx context.Context, organizationID uuid.UUID, _ EnvironmentFilter, pageSize int32, cursor *PageCursor) (EnvironmentListResult, error) {
 	environments, nextCursor, err := listEntities(ctx, s.pool,
 		fmt.Sprintf("SELECT %s FROM environments", environmentColumns),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -15,15 +15,14 @@ import (
 
 const (
 	agentColumns                     = `id, organization_id, name, nickname, role, model, description, configuration, image, init_image, idle_timeout, capabilities, availability, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, environment_id, default_thread, final_message, instance_idle_ttl, created_at, updated_at`
-	volumeColumns                    = `id, organization_id, persistent, mount_path, size, description, ttl, created_at, updated_at`
-	volumeAttachmentColumns          = `id, volume_id, agent_id, mcp_id, created_at, updated_at`
+	volumeColumns                    = `id, organization_id, environment_id, mcp_id, name, mount_path, persistent, size, storage_class, ttl, created_at, updated_at`
 	imagePullSecretAttachmentColumns = `id, organization_id, image_pull_secret_id, agent_id, mcp_id, environment_id, created_at, updated_at`
-	environmentColumns               = `id, organization_id, name, flavor_id, image, flavor_name, runner_id, flavor, workspace_image_id, workspace_image_tag, agent_runtime_image_id, agent_runtime_image_tag, created_at, updated_at`
+	environmentColumns               = `id, organization_id, name, flavor_id, image, flavor_name, runner_id, flavor, workspace_image_id, workspace_image_tag, agent_runtime_image_id, agent_runtime_image_tag, availability, created_at, updated_at`
 	sandboxColumns                   = `id, organization_id, name, environment_id, owner_id, status, idle_timeout, ttl, last_session_at, environment_name, workload_id, created_at, updated_at`
-	mcpColumns                       = `id, agent_id, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, image_id, image_tag, created_at, updated_at`
+	mcpColumns                       = `id, organization_id, agent_id, environment_id, shared_volumes, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, image_id, image_tag, created_at, updated_at`
 	skillColumns                     = `id, agent_id, name, body, description, created_at, updated_at`
 	envColumns                       = `id, organization_id, name, description, agent_id, mcp_id, environment_id, value, secret_id, created_at, updated_at`
-	initScriptColumns                = `id, script, description, agent_id, mcp_id, created_at, updated_at`
+	initScriptColumns                = `id, organization_id, script, description, name, agent_id, mcp_id, environment_id, created_at, updated_at`
 )
 
 type Store struct {
@@ -121,42 +120,32 @@ func scanAgent(row pgx.Row) (Agent, error) {
 
 func scanVolume(row pgx.Row) (Volume, error) {
 	var volume Volume
-	var ttl pgtype.Text
+	var environmentID, mcpID pgtype.UUID
+	var size, storageClass, ttl pgtype.Text
 	if err := row.Scan(
 		&volume.Meta.ID,
 		&volume.OrganizationID,
-		&volume.Persistent,
+		&environmentID,
+		&mcpID,
+		&volume.Name,
 		&volume.MountPath,
-		&volume.Size,
-		&volume.Description,
+		&volume.Persistent,
+		&size,
+		&storageClass,
 		&ttl,
 		&volume.Meta.CreatedAt,
 		&volume.Meta.UpdatedAt,
 	); err != nil {
 		return Volume{}, err
 	}
+	volume.EnvironmentID = uuidPtrFromPg(environmentID)
+	volume.McpID = uuidPtrFromPg(mcpID)
+	volume.Size = stringPtrFromPg(size)
+	volume.StorageClass = stringPtrFromPg(storageClass)
 	volume.TTL = stringPtrFromPg(ttl)
 	return volume, nil
 }
 
-func scanVolumeAttachment(row pgx.Row) (VolumeAttachment, error) {
-	var attachment VolumeAttachment
-	var agentID pgtype.UUID
-	var mcpID pgtype.UUID
-	if err := row.Scan(
-		&attachment.Meta.ID,
-		&attachment.VolumeID,
-		&agentID,
-		&mcpID,
-		&attachment.Meta.CreatedAt,
-		&attachment.Meta.UpdatedAt,
-	); err != nil {
-		return VolumeAttachment{}, err
-	}
-	attachment.AgentID = uuidPtrFromPg(agentID)
-	attachment.McpID = uuidPtrFromPg(mcpID)
-	return attachment, nil
-}
 
 func scanEnvironment(row pgx.Row) (Environment, error) {
 	var environment Environment
@@ -173,6 +162,7 @@ func scanEnvironment(row pgx.Row) (Environment, error) {
 		&environment.WorkspaceImageTag,
 		&environment.AgentRuntimeImageID,
 		&environment.AgentRuntimeImageTag,
+		&environment.Availability,
 		&environment.Meta.CreatedAt,
 		&environment.Meta.UpdatedAt,
 	); err != nil {
@@ -211,9 +201,13 @@ func scanSandbox(row pgx.Row) (Sandbox, error) {
 
 func scanMcp(row pgx.Row) (Mcp, error) {
 	var mcp Mcp
+	var agentID, environmentID, imageID pgtype.UUID
 	if err := row.Scan(
 		&mcp.Meta.ID,
-		&mcp.AgentID,
+		&mcp.OrganizationID,
+		&agentID,
+		&environmentID,
+		&mcp.SharedVolumes,
 		&mcp.Name,
 		&mcp.Image,
 		&mcp.Command,
@@ -222,13 +216,16 @@ func scanMcp(row pgx.Row) (Mcp, error) {
 		&mcp.Resources.LimitsCPU,
 		&mcp.Resources.LimitsMemory,
 		&mcp.Description,
-		&mcp.ImageID,
+		&imageID,
 		&mcp.ImageTag,
 		&mcp.Meta.CreatedAt,
 		&mcp.Meta.UpdatedAt,
 	); err != nil {
 		return Mcp{}, err
 	}
+	mcp.AgentID = uuidPtrFromPg(agentID)
+	mcp.EnvironmentID = uuidPtrFromPg(environmentID)
+	mcp.ImageID = uuidPtrFromPg(imageID)
 	return mcp, nil
 }
 
@@ -280,14 +277,16 @@ func scanEnv(row pgx.Row) (Env, error) {
 
 func scanInitScript(row pgx.Row) (InitScript, error) {
 	var script InitScript
-	var agentID pgtype.UUID
-	var mcpID pgtype.UUID
+	var agentID, mcpID, environmentID pgtype.UUID
 	if err := row.Scan(
 		&script.Meta.ID,
+		&script.OrganizationID,
 		&script.Script,
 		&script.Description,
+		&script.Name,
 		&agentID,
 		&mcpID,
+		&environmentID,
 		&script.Meta.CreatedAt,
 		&script.Meta.UpdatedAt,
 	); err != nil {
@@ -295,6 +294,7 @@ func scanInitScript(row pgx.Row) (InitScript, error) {
 	}
 	script.AgentID = uuidPtrFromPg(agentID)
 	script.McpID = uuidPtrFromPg(mcpID)
+	script.EnvironmentID = uuidPtrFromPg(environmentID)
 	return script, nil
 }
 
@@ -566,15 +566,11 @@ func (s *Store) ListAgents(ctx context.Context, organizationID *uuid.UUID, _ Age
 
 func (s *Store) CreateVolume(ctx context.Context, organizationID uuid.UUID, input VolumeInput) (Volume, error) {
 	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`INSERT INTO volumes (organization_id, persistent, mount_path, size, description, ttl)
-		 VALUES ($1, $2, $3, $4, $5, $6)
+		fmt.Sprintf(`INSERT INTO volumes (organization_id, environment_id, mcp_id, name, mount_path, persistent, size, storage_class, ttl)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING %s`, volumeColumns),
-		organizationID,
-		input.Persistent,
-		input.MountPath,
-		input.Size,
-		input.Description,
-		input.TTL,
+		organizationID, input.EnvironmentID, input.McpID, input.Name, input.MountPath,
+		input.Persistent, input.Size, input.StorageClass, input.TTL,
 	)
 	volume, err := scanVolume(row)
 	if err != nil {
@@ -600,75 +596,60 @@ func (s *Store) GetVolume(ctx context.Context, id uuid.UUID) (Volume, error) {
 
 func (s *Store) UpdateVolume(ctx context.Context, id uuid.UUID, update VolumeUpdate) (Volume, error) {
 	builder := updateBuilder{}
-	if update.Persistent != nil {
-		builder.add("persistent", *update.Persistent)
+	if update.Name != nil {
+		builder.add("name", *update.Name)
 	}
 	if update.MountPath != nil {
 		builder.add("mount_path", *update.MountPath)
 	}
+	if update.Persistent != nil {
+		builder.add("persistent", *update.Persistent)
+	}
 	if update.Size != nil {
 		builder.add("size", *update.Size)
 	}
-	if update.Description != nil {
-		builder.add("description", *update.Description)
+	if update.StorageClass != nil {
+		builder.add("storage_class", *update.StorageClass)
 	}
 	if update.TTL != nil {
 		builder.add("ttl", *update.TTL)
 	}
-
 	if builder.empty() {
 		return Volume{}, fmt.Errorf("volume update requires at least one field")
 	}
-
-	return withTx(ctx, s.pool, func(tx pgx.Tx) (Volume, error) {
-		query, args := builder.build("volumes", volumeColumns, id)
-		row := tx.QueryRow(ctx, query, args...)
-		volume, err := scanVolume(row)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return Volume{}, NotFound("volume")
-			}
-			return Volume{}, err
+	query, args := builder.build("volumes", volumeColumns, id)
+	row := s.pool.QueryRow(ctx, query, args...)
+	volume, err := scanVolume(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Volume{}, NotFound("volume")
 		}
-		agentIDs, err := agentIDsForVolume(ctx, tx, volume.Meta.ID)
-		if err != nil {
-			return Volume{}, err
-		}
-		if err := touchAgentsUpdatedAt(ctx, tx, agentIDs); err != nil {
-			return Volume{}, err
-		}
-		return volume, nil
-	})
+		return Volume{}, err
+	}
+	return volume, nil
 }
 
 func (s *Store) DeleteVolume(ctx context.Context, id uuid.UUID) error {
-	_, err := withTx(ctx, s.pool, func(tx pgx.Tx) (struct{}, error) {
-		agentIDs, err := agentIDsForVolume(ctx, tx, id)
-		if err != nil {
-			return struct{}{}, err
-		}
-		result, err := tx.Exec(ctx, `DELETE FROM volumes WHERE id = $1`, id)
-		if err != nil {
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-				return struct{}{}, ForeignKeyViolation("volume")
-			}
-			return struct{}{}, err
-		}
-		if result.RowsAffected() == 0 {
-			return struct{}{}, NotFound("volume")
-		}
-		if err := touchAgentsUpdatedAt(ctx, tx, agentIDs); err != nil {
-			return struct{}{}, err
-		}
-		return struct{}{}, nil
-	})
-	return err
+	result, err := s.pool.Exec(ctx, `DELETE FROM volumes WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return NotFound("volume")
+	}
+	return nil
 }
 
-func (s *Store) ListVolumes(ctx context.Context, organizationID uuid.UUID, _ VolumeFilter, pageSize int32, cursor *PageCursor) (VolumeListResult, error) {
-	clauses := []string{"organization_id = $1"}
-	args := []any{organizationID}
+func (s *Store) ListVolumes(ctx context.Context, organizationID uuid.UUID, filter VolumeFilter, pageSize int32, cursor *PageCursor) (VolumeListResult, error) {
+	var clauses []string
+	var args []any
+	clauses, args = appendClause(clauses, args, "organization_id = $%d", organizationID)
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
+	}
+	if filter.McpID != nil {
+		clauses, args = appendClause(clauses, args, "mcp_id = $%d", *filter.McpID)
+	}
 	volumes, nextCursor, err := listEntities(ctx, s.pool,
 		fmt.Sprintf("SELECT %s FROM volumes", volumeColumns),
 		clauses,
@@ -688,115 +669,20 @@ func (s *Store) ListAgentIDsForVolume(ctx context.Context, volumeID uuid.UUID) (
 	return agentIDsForVolume(ctx, s.pool, volumeID)
 }
 
-func (s *Store) CreateVolumeAttachment(ctx context.Context, input VolumeAttachmentInput) (VolumeAttachment, error) {
-	return withTx(ctx, s.pool, func(tx pgx.Tx) (VolumeAttachment, error) {
-		row := tx.QueryRow(ctx,
-			fmt.Sprintf(`INSERT INTO volume_attachments (volume_id, agent_id, mcp_id)
-		 VALUES ($1, $2, $3)
-		 RETURNING %s`, volumeAttachmentColumns),
-			input.VolumeID,
-			input.AgentID,
-			input.McpID,
-		)
-		attachment, err := scanVolumeAttachment(row)
-		if err != nil {
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) {
-				switch pgErr.Code {
-				case "23505":
-					return VolumeAttachment{}, AlreadyExists("volume attachment")
-				case "23503":
-					return VolumeAttachment{}, ForeignKeyViolation("volume attachment")
-				}
-			}
-			return VolumeAttachment{}, err
-		}
-		agentID, err := resolveAgentID(ctx, tx, attachment.AgentID, attachment.McpID)
-		if err != nil {
-			return VolumeAttachment{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
-			return VolumeAttachment{}, err
-		}
-		return attachment, nil
-	})
-}
 
-func (s *Store) GetVolumeAttachment(ctx context.Context, id uuid.UUID) (VolumeAttachment, error) {
-	row := s.pool.QueryRow(ctx,
-		fmt.Sprintf(`SELECT %s FROM volume_attachments WHERE id = $1`, volumeAttachmentColumns),
-		id,
-	)
-	attachment, err := scanVolumeAttachment(row)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return VolumeAttachment{}, NotFound("volume attachment")
-		}
-		return VolumeAttachment{}, err
-	}
-	return attachment, nil
-}
 
-func (s *Store) DeleteVolumeAttachment(ctx context.Context, id uuid.UUID) error {
-	_, err := withTx(ctx, s.pool, func(tx pgx.Tx) (struct{}, error) {
-		row := tx.QueryRow(ctx,
-			fmt.Sprintf(`DELETE FROM volume_attachments WHERE id = $1 RETURNING %s`, volumeAttachmentColumns),
-			id,
-		)
-		attachment, err := scanVolumeAttachment(row)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return struct{}{}, NotFound("volume attachment")
-			}
-			return struct{}{}, err
-		}
-		agentID, err := resolveAgentID(ctx, tx, attachment.AgentID, attachment.McpID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
-			return struct{}{}, err
-		}
-		return struct{}{}, nil
-	})
-	return err
-}
 
-func (s *Store) ListVolumeAttachments(ctx context.Context, filter VolumeAttachmentFilter, pageSize int32, cursor *PageCursor) (VolumeAttachmentListResult, error) {
-	clauses := []string{}
-	args := []any{}
-	if filter.VolumeID != nil {
-		clauses, args = appendClause(clauses, args, "volume_id = $%d", *filter.VolumeID)
-	}
-	if filter.AgentID != nil {
-		clauses, args = appendClause(clauses, args, "agent_id = $%d", *filter.AgentID)
-	}
-	if filter.McpID != nil {
-		clauses, args = appendClause(clauses, args, "mcp_id = $%d", *filter.McpID)
-	}
 
-	attachments, nextCursor, err := listEntities(ctx, s.pool,
-		fmt.Sprintf("SELECT %s FROM volume_attachments", volumeAttachmentColumns),
-		clauses,
-		args,
-		cursor,
-		pageSize,
-		scanVolumeAttachment,
-		func(attachment VolumeAttachment) uuid.UUID { return attachment.Meta.ID },
-	)
-	if err != nil {
-		return VolumeAttachmentListResult{}, err
-	}
-	return VolumeAttachmentListResult{VolumeAttachments: attachments, NextCursor: nextCursor}, nil
-}
-
-func (s *Store) CreateMcp(ctx context.Context, input McpInput) (Mcp, error) {
+func (s *Store) CreateMcp(ctx context.Context, organizationID uuid.UUID, input McpInput) (Mcp, error) {
 	return withTx(ctx, s.pool, func(tx pgx.Tx) (Mcp, error) {
 		row := tx.QueryRow(ctx,
-			fmt.Sprintf(`INSERT INTO mcps (agent_id, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, image_id, image_tag)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			fmt.Sprintf(`INSERT INTO mcps (organization_id, agent_id, environment_id, shared_volumes, name, image, command, resources_requests_cpu, resources_requests_memory, resources_limits_cpu, resources_limits_memory, description, image_id, image_tag)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		 RETURNING %s`, mcpColumns),
+			organizationID,
 			input.AgentID,
+			input.EnvironmentID,
+			input.SharedVolumes,
 			input.Name,
 			input.Image,
 			input.Command,
@@ -821,7 +707,7 @@ func (s *Store) CreateMcp(ctx context.Context, input McpInput) (Mcp, error) {
 			}
 			return Mcp{}, err
 		}
-		if err := touchAgentUpdatedAt(ctx, tx, mcp.AgentID); err != nil {
+		if err := touchTargetUpdatedAt(ctx, tx, mcp.AgentID, mcp.EnvironmentID); err != nil {
 			return Mcp{}, err
 		}
 		return mcp, nil
@@ -880,7 +766,7 @@ func (s *Store) UpdateMcp(ctx context.Context, id uuid.UUID, update McpUpdate) (
 			}
 			return Mcp{}, err
 		}
-		if err := touchAgentUpdatedAt(ctx, tx, mcp.AgentID); err != nil {
+		if err := touchTargetUpdatedAt(ctx, tx, mcp.AgentID, mcp.EnvironmentID); err != nil {
 			return Mcp{}, err
 		}
 		return mcp, nil
@@ -904,7 +790,7 @@ func (s *Store) DeleteMcp(ctx context.Context, id uuid.UUID) error {
 			}
 			return struct{}{}, err
 		}
-		if err := touchAgentUpdatedAt(ctx, tx, mcp.AgentID); err != nil {
+		if err := touchTargetUpdatedAt(ctx, tx, mcp.AgentID, mcp.EnvironmentID); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -1190,16 +1076,19 @@ func (s *Store) ListEnvs(ctx context.Context, filter EnvFilter, pageSize int32, 
 	return EnvListResult{Envs: envs, NextCursor: nextCursor}, nil
 }
 
-func (s *Store) CreateInitScript(ctx context.Context, input InitScriptInput) (InitScript, error) {
+func (s *Store) CreateInitScript(ctx context.Context, organizationID uuid.UUID, input InitScriptInput) (InitScript, error) {
 	return withTx(ctx, s.pool, func(tx pgx.Tx) (InitScript, error) {
 		row := tx.QueryRow(ctx,
-			fmt.Sprintf(`INSERT INTO init_scripts (script, description, agent_id, mcp_id)
-		 VALUES ($1, $2, $3, $4)
+			fmt.Sprintf(`INSERT INTO init_scripts (organization_id, script, description, name, agent_id, mcp_id, environment_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
 		 RETURNING %s`, initScriptColumns),
+			organizationID,
 			input.Script,
 			input.Description,
+			input.Name,
 			input.AgentID,
 			input.McpID,
+			input.EnvironmentID,
 		)
 		script, err := scanInitScript(row)
 		if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -573,6 +573,17 @@ func (s *Store) CreateVolume(ctx context.Context, organizationID uuid.UUID, inpu
 	)
 	volume, err := scanVolume(row)
 	if err != nil {
+		// A name or path already used in this target is the caller's mistake,
+		// not an internal failure, and saying which is the whole point.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return Volume{}, AlreadyExists("volume")
+			case "23503":
+				return Volume{}, ForeignKeyViolation("volume")
+			}
+		}
 		return Volume{}, err
 	}
 	return volume, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -146,7 +146,6 @@ func scanVolume(row pgx.Row) (Volume, error) {
 	return volume, nil
 }
 
-
 func scanEnvironment(row pgx.Row) (Environment, error) {
 	var environment Environment
 	if err := row.Scan(
@@ -650,6 +649,9 @@ func (s *Store) ListVolumes(ctx context.Context, organizationID uuid.UUID, filte
 	if filter.McpID != nil {
 		clauses, args = appendClause(clauses, args, "mcp_id = $%d", *filter.McpID)
 	}
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
+	}
 	volumes, nextCursor, err := listEntities(ctx, s.pool,
 		fmt.Sprintf("SELECT %s FROM volumes", volumeColumns),
 		clauses,
@@ -669,9 +671,12 @@ func (s *Store) ListAgentIDsForVolume(ctx context.Context, volumeID uuid.UUID) (
 	return agentIDsForVolume(ctx, s.pool, volumeID)
 }
 
-
-
-
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
 
 func (s *Store) CreateMcp(ctx context.Context, organizationID uuid.UUID, input McpInput) (Mcp, error) {
 	return withTx(ctx, s.pool, func(tx pgx.Tx) (Mcp, error) {
@@ -682,7 +687,9 @@ func (s *Store) CreateMcp(ctx context.Context, organizationID uuid.UUID, input M
 			organizationID,
 			input.AgentID,
 			input.EnvironmentID,
-			input.SharedVolumes,
+			// A nil slice reaches Postgres as NULL rather than taking the
+			// column default, and most MCPs share nothing.
+			nonNilStrings(input.SharedVolumes),
 			input.Name,
 			input.Image,
 			input.Command,
@@ -803,6 +810,9 @@ func (s *Store) ListMcps(ctx context.Context, filter McpFilter, pageSize int32, 
 	args := []any{}
 	if filter.AgentID != nil {
 		clauses, args = appendClause(clauses, args, "agent_id = $%d", *filter.AgentID)
+	}
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
 	}
 
 	mcps, nextCursor, err := listEntities(ctx, s.pool,

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -74,6 +74,27 @@ const (
 	AgentAvailabilityPrivate  AgentAvailability = "private"
 )
 
+type EnvironmentAvailability string
+
+const (
+	EnvironmentAvailabilityInternal EnvironmentAvailability = "internal"
+	EnvironmentAvailabilityPrivate  EnvironmentAvailability = "private"
+)
+
+type EnvironmentRole string
+
+const (
+	EnvironmentRoleOwner      EnvironmentRole = "owner"
+	EnvironmentRoleMaintainer EnvironmentRole = "maintainer"
+	EnvironmentRoleUser       EnvironmentRole = "user"
+)
+
+type EnvironmentRoleAssignment struct {
+	EnvironmentID uuid.UUID
+	IdentityID    uuid.UUID
+	Role          EnvironmentRole
+}
+
 type AgentRole string
 
 const (
@@ -180,28 +201,27 @@ type InboxItemListResult struct {
 type Volume struct {
 	Meta           EntityMeta
 	OrganizationID uuid.UUID
-	Persistent     bool
+	EnvironmentID  *uuid.UUID
+	McpID          *uuid.UUID
+	Name           string
 	MountPath      string
-	Size           string
-	Description    string
+	Persistent     bool
+	Size           *string
+	StorageClass   *string
 	TTL            *string
 }
 
-type VolumeAttachment struct {
-	Meta     EntityMeta
-	VolumeID uuid.UUID
-	AgentID  *uuid.UUID
-	McpID    *uuid.UUID
-}
-
 type Mcp struct {
-	Meta        EntityMeta
-	AgentID     uuid.UUID
-	Name        string
-	Image       string
-	Command     string
-	Resources   ComputeResources
-	Description string
+	Meta           EntityMeta
+	OrganizationID uuid.UUID
+	AgentID        *uuid.UUID
+	EnvironmentID  *uuid.UUID
+	SharedVolumes  []string
+	Name           string
+	Image          string
+	Command        string
+	Resources      ComputeResources
+	Description    string
 	// The catalog record this sidecar runs, superseding Image.
 	ImageID  *uuid.UUID
 	ImageTag string
@@ -247,6 +267,7 @@ type Environment struct {
 	WorkspaceImageTag    string
 	AgentRuntimeImageID  *uuid.UUID
 	AgentRuntimeImageTag string
+	Availability         EnvironmentAvailability
 }
 
 type Sandbox struct {
@@ -264,11 +285,14 @@ type Sandbox struct {
 }
 
 type InitScript struct {
-	Meta        EntityMeta
-	Script      string
-	Description string
-	AgentID     *uuid.UUID
-	McpID       *uuid.UUID
+	Meta           EntityMeta
+	OrganizationID uuid.UUID
+	Script         string
+	Description    string
+	Name           string
+	AgentID        *uuid.UUID
+	McpID          *uuid.UUID
+	EnvironmentID  *uuid.UUID
 }
 
 type AgentInput struct {
@@ -313,45 +337,51 @@ type AgentUpdate struct {
 }
 
 type VolumeInput struct {
-	Persistent  bool
-	MountPath   string
-	Size        string
-	Description string
-	TTL         *string
+	EnvironmentID *uuid.UUID
+	McpID         *uuid.UUID
+	Name          string
+	MountPath     string
+	Persistent    bool
+	Size          *string
+	StorageClass  *string
+	TTL           *string
 }
 
 type VolumeUpdate struct {
-	Persistent  *bool
-	MountPath   *string
-	Size        *string
-	Description *string
-	TTL         *string
+	Name         *string
+	MountPath    *string
+	Persistent   *bool
+	Size         **string
+	StorageClass **string
+	TTL          **string
 }
 
-type VolumeAttachmentInput struct {
-	VolumeID uuid.UUID
-	AgentID  *uuid.UUID
-	McpID    *uuid.UUID
+type VolumeFilter struct {
+	EnvironmentID *uuid.UUID
+	McpID         *uuid.UUID
 }
 
 type McpInput struct {
-	AgentID     uuid.UUID
-	Name        string
-	Image       string
-	Command     string
-	Resources   ComputeResources
-	Description string
-	ImageID     *uuid.UUID
-	ImageTag    string
+	AgentID       *uuid.UUID
+	EnvironmentID *uuid.UUID
+	SharedVolumes []string
+	Name          string
+	Image         string
+	Command       string
+	Resources     ComputeResources
+	Description   string
+	ImageID       *uuid.UUID
+	ImageTag      string
 }
 
 type McpUpdate struct {
-	Image       *string
-	Command     *string
-	Resources   *ComputeResources
-	Description *string
-	ImageID     **uuid.UUID
-	ImageTag    *string
+	SharedVolumes *[]string
+	Image         *string
+	Command       *string
+	Resources     *ComputeResources
+	Description   *string
+	ImageID       **uuid.UUID
+	ImageTag      *string
 }
 
 type SkillInput struct {
@@ -385,10 +415,12 @@ type EnvUpdate struct {
 }
 
 type InitScriptInput struct {
-	Script      string
-	Description string
-	AgentID     *uuid.UUID
-	McpID       *uuid.UUID
+	Script        string
+	Description   string
+	Name          string
+	AgentID       *uuid.UUID
+	McpID         *uuid.UUID
+	EnvironmentID *uuid.UUID
 }
 
 type InitScriptUpdate struct {
@@ -397,6 +429,7 @@ type InitScriptUpdate struct {
 }
 
 type EnvironmentInput struct {
+	Availability         EnvironmentAvailability
 	Name                 string
 	Image                string
 	RunnerID             *uuid.UUID
@@ -408,10 +441,11 @@ type EnvironmentInput struct {
 }
 
 type EnvironmentUpdate struct {
-	Name     *string
-	Image    *string
-	RunnerID *uuid.UUID
-	Flavor   *string
+	Availability *EnvironmentAvailability
+	Name         *string
+	Image        *string
+	RunnerID     *uuid.UUID
+	Flavor       *string
 	// Double pointers: the outer says the caller named the field, the inner
 	// says what to set. Clearing the agent runtime pair is how an environment
 	// becomes workspace-only.
@@ -439,16 +473,9 @@ type SandboxUpdate struct {
 
 type AgentFilter struct{}
 
-type VolumeFilter struct{}
-
-type VolumeAttachmentFilter struct {
-	VolumeID *uuid.UUID
-	AgentID  *uuid.UUID
-	McpID    *uuid.UUID
-}
-
 type McpFilter struct {
-	AgentID *uuid.UUID
+	AgentID       *uuid.UUID
+	EnvironmentID *uuid.UUID
 }
 
 type SkillFilter struct {
@@ -467,8 +494,9 @@ type EnvFilter struct {
 }
 
 type InitScriptFilter struct {
-	AgentID *uuid.UUID
-	McpID   *uuid.UUID
+	AgentID       *uuid.UUID
+	McpID         *uuid.UUID
+	EnvironmentID *uuid.UUID
 }
 
 type EnvironmentFilter struct{}
@@ -495,11 +523,6 @@ type AgentListResult struct {
 type VolumeListResult struct {
 	Volumes    []Volume
 	NextCursor *PageCursor
-}
-
-type VolumeAttachmentListResult struct {
-	VolumeAttachments []VolumeAttachment
-	NextCursor        *PageCursor
 }
 
 type McpListResult struct {

--- a/migrations/0024_volumes_on_environments.sql
+++ b/migrations/0024_volumes_on_environments.sql
@@ -1,0 +1,132 @@
+-- A volume described nothing that existed until something mounted it: a
+-- free-standing organization row holding a mount path and a size, reaching a
+-- workload only through a separate attachment. It becomes a sub-resource of the
+-- thing that mounts it.
+--
+-- Nothing is translated. A definition carried no name and no target, so there
+-- is no answer to which environment an existing row belonged to that is not a
+-- guess. Operators redeclare storage on the environments that need it.
+DROP TABLE IF EXISTS volume_attachments;
+DROP TABLE IF EXISTS volumes;
+
+CREATE TABLE volumes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL,
+    environment_id UUID,
+    mcp_id UUID REFERENCES mcps(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    mount_path TEXT NOT NULL,
+    persistent BOOLEAN NOT NULL DEFAULT FALSE,
+    size TEXT,
+    storage_class TEXT,
+    ttl TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT volumes_target_check CHECK (
+        (environment_id IS NOT NULL)::int + (mcp_id IS NOT NULL)::int = 1
+    ),
+    -- size and persistence are biconditional, which is what lets the CLI make
+    -- --size the whole control: given, the volume is a disk; omitted, scratch.
+    CONSTRAINT volumes_size_check CHECK (
+        persistent = (size IS NOT NULL AND size <> '')
+    ),
+    -- Composite, as sandboxes reference environments, so a volume and the
+    -- environment it targets cannot drift into different organizations.
+    CONSTRAINT volumes_environment_fkey FOREIGN KEY (organization_id, environment_id)
+        REFERENCES environments (organization_id, id) ON DELETE CASCADE
+);
+
+-- Names are the contract MCPs reference, and paths are what a container sees;
+-- both are unique within one target and deliberately reusable across targets.
+CREATE UNIQUE INDEX volumes_environment_name_idx ON volumes (environment_id, name) WHERE environment_id IS NOT NULL;
+CREATE UNIQUE INDEX volumes_environment_path_idx ON volumes (environment_id, mount_path) WHERE environment_id IS NOT NULL;
+CREATE UNIQUE INDEX volumes_mcp_name_idx ON volumes (mcp_id, name) WHERE mcp_id IS NOT NULL;
+CREATE UNIQUE INDEX volumes_mcp_path_idx ON volumes (mcp_id, mount_path) WHERE mcp_id IS NOT NULL;
+CREATE INDEX volumes_organization_id_idx ON volumes (organization_id);
+
+-- An MCP belonged to an agent and carried no organization of its own, so an
+-- environment could not define one and a row could not be scoped without
+-- walking to its agent.
+ALTER TABLE mcps
+    ADD COLUMN organization_id UUID,
+    ADD COLUMN environment_id UUID,
+    ADD COLUMN shared_volumes TEXT[] NOT NULL DEFAULT '{}';
+
+UPDATE mcps
+SET organization_id = agents.organization_id
+FROM agents
+WHERE mcps.agent_id = agents.id;
+
+-- Every row must resolve. A row that does not is corruption no automatic choice
+-- can repair, and migrations apply in one transaction, so stopping leaves the
+-- database exactly as it was.
+DO $$
+DECLARE
+    unresolved BIGINT;
+BEGIN
+    SELECT count(*) INTO unresolved FROM mcps WHERE organization_id IS NULL;
+    IF unresolved > 0 THEN
+        RAISE EXCEPTION 'mcps: % row(s) reach no organization through agent_id', unresolved;
+    END IF;
+END
+$$;
+
+ALTER TABLE mcps
+    ALTER COLUMN organization_id SET NOT NULL,
+    ALTER COLUMN agent_id DROP NOT NULL,
+    ADD CONSTRAINT mcps_target_check CHECK (
+        (agent_id IS NOT NULL)::int + (environment_id IS NOT NULL)::int = 1
+    ),
+    ADD CONSTRAINT mcps_environment_fkey FOREIGN KEY (organization_id, environment_id)
+        REFERENCES environments (organization_id, id) ON DELETE CASCADE;
+
+CREATE INDEX mcps_organization_id_idx ON mcps (organization_id);
+CREATE INDEX mcps_environment_id_idx ON mcps (environment_id);
+CREATE UNIQUE INDEX mcps_environment_name_idx ON mcps (environment_id, name) WHERE environment_id IS NOT NULL;
+
+-- An init script joins ENV in accepting an environment: what a workload runs
+-- before its agent CLI is a property of the environment, not only of the agent.
+ALTER TABLE init_scripts
+    ADD COLUMN organization_id UUID,
+    ADD COLUMN environment_id UUID,
+    ADD COLUMN name TEXT NOT NULL DEFAULT '';
+
+UPDATE init_scripts
+SET organization_id = agents.organization_id
+FROM agents
+WHERE init_scripts.agent_id = agents.id;
+
+UPDATE init_scripts
+SET organization_id = mcps.organization_id
+FROM mcps
+WHERE init_scripts.mcp_id = mcps.id;
+
+DO $$
+DECLARE
+    unresolved BIGINT;
+BEGIN
+    SELECT count(*) INTO unresolved FROM init_scripts WHERE organization_id IS NULL;
+    IF unresolved > 0 THEN
+        RAISE EXCEPTION 'init_scripts: % row(s) reach no organization through agent_id or mcp_id', unresolved;
+    END IF;
+END
+$$;
+
+ALTER TABLE init_scripts
+    ALTER COLUMN organization_id SET NOT NULL,
+    DROP CONSTRAINT IF EXISTS init_scripts_check,
+    ADD CONSTRAINT init_scripts_target_check CHECK (
+        (agent_id IS NOT NULL)::int + (mcp_id IS NOT NULL)::int + (environment_id IS NOT NULL)::int = 1
+    ),
+    ADD CONSTRAINT init_scripts_environment_fkey FOREIGN KEY (organization_id, environment_id)
+        REFERENCES environments (organization_id, id) ON DELETE CASCADE;
+
+CREATE INDEX init_scripts_organization_id_idx ON init_scripts (organization_id);
+CREATE INDEX init_scripts_environment_id_idx ON init_scripts (environment_id);
+
+-- Running in an environment reaches its secrets, egress credentials and volume
+-- contents, so it is a grant of its own rather than a consequence of being able
+-- to see the environment. Existing environments stay reachable by any member.
+ALTER TABLE environments
+    ADD COLUMN availability TEXT NOT NULL DEFAULT 'internal'
+        CHECK (availability IN ('internal', 'private'));

--- a/migrations/0025_environment_roles.sql
+++ b/migrations/0025_environment_roles.sql
@@ -1,0 +1,14 @@
+-- Environments carry the same two-layer model agents do: any member may author
+-- one, and who else may read, edit or run in it is a per-environment grant.
+-- `user` is the role agents have no equivalent of -- it opens an interactive
+-- shell onto the environment without any configuration access.
+CREATE TABLE environment_roles (
+    environment_id UUID NOT NULL REFERENCES environments(id) ON DELETE CASCADE,
+    identity_id UUID NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('owner', 'maintainer', 'user')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (environment_id, identity_id)
+);
+
+CREATE INDEX idx_environment_roles_identity ON environment_roles (identity_id);


### PR DESCRIPTION
A volume was a free-standing organization row reaching a workload through a
separate attachment, describing nothing that existed until something mounted it.
It becomes a sub-resource of the environment or MCP that mounts it.

**No migration.** A definition carried no name and no target, so which
environment an existing row belonged to has no answer that is not a guess.
Operators redeclare storage where it is needed.

## Also here

- MCPs and init scripts take an environment target, and both gain an
  organization of their own rather than reaching one by walking to an agent.
- `Environment.availability`, required on create with no default.
- Environment tuple lifecycle, the role API, and `can_use` on `CreateSandbox`
  and on any `CreateAgent`/`UpdateAgent` naming an environment.
- Configuration reads (`ListVolumes`/`ListMcps`/`ListInitScripts`/`ListEnvs`
  scoped to an environment) require `can_read_config`; metadata stays on
  membership so pickers still populate.
- `environment.updated` on one room. Sub-resource writes previously published
  **nothing at all**, so the Orchestrator never learned of them.
- An idempotent startup backfill: environments predating the type carry no
  tuples, and without an `org` tuple every check refuses, including an
  organization owner's.

Requires agynio/authorization#35 for the OpenFGA type, or environment checks
fail with `type 'environment' not found`.

Spec: `architecture/changes/2026-08-06-volumes-on-environments.md`