### PR TITLE
Take the generated protobuf from the sync, not the BSR

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -35,7 +35,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/images/v1 --path agynio/api/notifications/v1 --path agynio/api/organizations/v1
+                  [ -d /opt/app/data/.gen ] || buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/images/v1 --path agynio/api/notifications/v1 --path agynio/api/organizations/v1
                   exec go run ./cmd/agents-service
               volumeMounts:
                 - name: data
@@ -108,12 +108,10 @@ dev:
             excludePaths:
               - .git/
               - .devspace/
-              - /.gen/
               - /tmp/
             uploadExcludePaths:
               - .git/
               - .devspace/
-              - /.gen/
               - /tmp/
               - /e2e/
               - /bootstrap/


### PR DESCRIPTION
Every container start regenerated from buf.build, so a pod that restarted often enough was rate limited out of building at all — `resource_exhausted`, crashloop, and each retry spent more of the budget that would have let it recover. The generated code is identical between starts, so the fetch bought nothing.

- `.gen` syncs up with the source (removed from `excludePaths` and `uploadExcludePaths`; still excluded from download so the pod never overwrites the local copy)
- `buf generate` runs only when `.gen` is absent

Same change as agents-orchestrator#250.