### PR TITLE
Publish sandbox updates to the sandbox's own room

### DIFF
--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -111,6 +111,10 @@ func (s *Server) publishSandboxUpdated(ctx context.Context, sandbox store.Sandbo
 		Rooms: []string{
 			fmt.Sprintf("sandbox_owner:%s", sandbox.OwnerID),
 			fmt.Sprintf("sandbox_org:%s", sandbox.OrganizationID),
+			// Keyed by the sandbox rather than its owner, so it also reaches a
+			// viewer who is not the owner -- the detail view of a sandbox an
+			// organization owner did not create.
+			fmt.Sprintf("sandbox:%s", sandbox.Meta.ID),
 		},
 		Payload: payload,
 		Source:  "agents",

--- a/internal/server/notifications_test.go
+++ b/internal/server/notifications_test.go
@@ -47,6 +47,7 @@ func TestPublishSandboxUpdatedIncludesSnapshotPayload(t *testing.T) {
 	assertRooms(t, request.GetRooms(), []string{
 		"sandbox_owner:" + sandbox.OwnerID.String(),
 		"sandbox_org:" + sandbox.OrganizationID.String(),
+		"sandbox:" + sandbox.Meta.ID.String(),
 	})
 	fields := request.GetPayload().GetFields()
 	assertStringField(t, fields, "sandbox_id", sandbox.Meta.ID.String())


### PR DESCRIPTION
`sandbox.updated` reached `sandbox_owner` and `sandbox_org` only — neither carries an update to someone watching one particular sandbox that is not theirs.

The room agynio/notifications#42 admits was therefore silent. This publishes to it.

Part of a three-repo change with agynio/authorization#39 and agynio/notifications#42.