### PR TITLE
Constrain the sandbox name to a valid DNS label

### DIFF
--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -75,6 +75,12 @@ func TestValidateSandboxName(t *testing.T) {
 		{name: "Brave", wantErr: true},
 		{name: "brave_otter", wantErr: true},
 		{name: strings.Repeat("a", 64), wantErr: true},
+		// The name is a hostname label in an exposed port's address.
+		{name: "-brave", wantErr: true},
+		{name: "brave-", wantErr: true},
+		{name: "-", wantErr: true},
+		{name: "a"},
+		{name: strings.Repeat("a", 63)},
 	}
 
 	for _, test := range tests {

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -25,7 +25,11 @@ const (
 )
 
 var (
-	sandboxNamePattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+	// A valid DNS label. The Expose service puts the sandbox name in a
+	// hostname -- an exposed port is reachable at <sandbox>.<org-slug>.agyn --
+	// so leading and trailing hyphens, which the previous ^[a-z0-9-]+$ allowed
+	// and a hostname rejects, are not usable names.
+	sandboxNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 	sandboxAdjectives  = []string{"brave", "calm", "eager", "gentle", "lucky", "nimble", "quiet", "rapid"}
 	sandboxNouns       = []string{"badger", "falcon", "otter", "panda", "raven", "tiger", "yak", "zebra"}
 )


### PR DESCRIPTION
Supports agynio/expose#36.

A sandbox's exposed ports are reachable at `<sandbox>.<org-slug>.agyn`, so the name is a hostname label. The 63-character cap was already right; the pattern was not — `^[a-z0-9-]+$` admitted leading and trailing hyphens a hostname rejects.

Generated names were never affected: `adjective-noun-hex` cannot produce one.