### PR TITLE
Delete a volume without consulting the attachments table

### DIFF
--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -141,17 +141,6 @@ func (s *Server) resolveAgentID(ctx context.Context, agentID *uuid.UUID, mcpID *
 	return uuid.UUID{}, fmt.Errorf("missing target identifier")
 }
 
-func (s *Server) publishAgentUpdatedForVolume(ctx context.Context, volumeID uuid.UUID) {
-	agentIDs, err := s.store.ListAgentIDsForVolume(ctx, volumeID)
-	if err != nil {
-		log.Printf("agents: list volume agents: %v", err)
-		return
-	}
-	for _, agentID := range agentIDs {
-		s.publishAgentUpdatedByID(ctx, agentID)
-	}
-}
-
 // publishAgentUpdatedForConfigTarget notifies the agent whose configuration the
 // row is part of. A row on an environment is part of no agent's configuration —
 // an environment belongs to an organization — and there is nothing to notify.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -857,16 +857,16 @@ func (s *Server) DeleteVolume(ctx context.Context, req *agentsv1.DeleteVolumeReq
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	agentIDs, err := s.store.ListAgentIDsForVolume(ctx, id)
+	// Read before the delete: the target names who to notify, and it is gone
+	// with the row.
+	volume, err := s.store.GetVolume(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
 	if err := s.store.DeleteVolume(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
-	for _, agentID := range agentIDs {
-		s.publishAgentUpdatedByID(ctx, agentID)
-	}
+	s.publishVolumeTargetUpdated(ctx, volume)
 	return &agentsv1.DeleteVolumeResponse{}, nil
 }
 

--- a/internal/store/agent_helpers.go
+++ b/internal/store/agent_helpers.go
@@ -131,29 +131,3 @@ func agentIDForMcp(ctx context.Context, tx pgx.Tx, mcpID uuid.UUID) (uuid.UUID, 
 	return agentID, nil
 }
 
-func agentIDsForVolume(ctx context.Context, queryer agentIDQueryer, volumeID uuid.UUID) ([]uuid.UUID, error) {
-	rows, err := queryer.Query(ctx,
-		`SELECT DISTINCT COALESCE(va.agent_id, mcps.agent_id)
-FROM volume_attachments va
-LEFT JOIN mcps ON va.mcp_id = mcps.id
-WHERE va.volume_id = $1`,
-		volumeID,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	agents := make([]uuid.UUID, 0)
-	for rows.Next() {
-		var agentID uuid.UUID
-		if err := rows.Scan(&agentID); err != nil {
-			return nil, err
-		}
-		agents = append(agents, agentID)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return agents, nil
-}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -685,10 +685,6 @@ func (s *Store) ListVolumes(ctx context.Context, organizationID uuid.UUID, filte
 	return VolumeListResult{Volumes: volumes, NextCursor: nextCursor}, nil
 }
 
-func (s *Store) ListAgentIDsForVolume(ctx context.Context, volumeID uuid.UUID) ([]uuid.UUID, error) {
-	return agentIDsForVolume(ctx, s.pool, volumeID)
-}
-
 func nonNilStrings(values []string) []string {
 	if values == nil {
 		return []string{}


### PR DESCRIPTION
`terraform destroy` on an `agyn_volume` fails with:

    delete volume: internal: internal error: ERROR: relation "volume_attachments" does not exist (SQLSTATE 42P01)

`0024_volumes_on_environments.sql` dropped `volume_attachments`, but `DeleteVolume` still resolved the agents to notify through it and returned the error rather than degrading. Create and update already notify the volume's target through `publishVolumeTargetUpdated`; delete now does the same, reading the volume first because the target goes with the row.

Removes the attachment-era `agentIDsForVolume` / `ListAgentIDsForVolume` and `publishAgentUpdatedForVolume`, which had no callers left.

Found while verifying the Terraform provider's volume resource against a local platform — volumes could be created and updated but never deleted.