### PR TITLE
Scope an environment's init scripts to that environment

### DIFF
--- a/internal/server/environment_authorization_db_test.go
+++ b/internal/server/environment_authorization_db_test.go
@@ -50,6 +50,9 @@ func seedEnvironment(ctx context.Context, t *testing.T, backing *store.Store, or
 		RunnerID:     &runnerID,
 		Flavor:       "small",
 		Availability: store.EnvironmentAvailabilityPrivate,
+		// The column is CHECK-constrained; the handler defaults it, so a seed
+		// going straight to the store has to name it.
+		LLMMode: store.LLMModePlatform,
 	})
 	if err != nil {
 		t.Fatalf("seed environment: %v", err)

--- a/internal/server/environment_scope_db_test.go
+++ b/internal/server/environment_scope_db_test.go
@@ -24,6 +24,8 @@ func TestEnvironmentScopedListsAreScoped(t *testing.T) {
 	mustCreateMcp(ctx, t, server, second, "beta")
 	mustCreateVolume(ctx, t, server, first, "data", "/data")
 	mustCreateVolume(ctx, t, server, second, "cache", "/cache")
+	mustCreateInitScript(ctx, t, server, first, "echo first")
+	mustCreateInitScript(ctx, t, server, second, "echo second")
 
 	mcps, err := server.ListMcps(ctx, &agentsv1.ListMcpsRequest{EnvironmentId: first})
 	if err != nil {
@@ -45,8 +47,8 @@ func TestEnvironmentScopedListsAreScoped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list init scripts: %v", err)
 	}
-	if len(scripts.GetInitScripts()) != 0 {
-		t.Fatalf("expected no scripts on the first environment, got %d", len(scripts.GetInitScripts()))
+	if len(scripts.GetInitScripts()) != 1 || scripts.GetInitScripts()[0].GetScript() != "echo first" {
+		t.Fatalf("expected only the first environment's script, got %d", len(scripts.GetInitScripts()))
 	}
 }
 
@@ -56,6 +58,16 @@ func mustCreateMcp(ctx context.Context, t *testing.T, server *Server, environmen
 		EnvironmentId: environmentID, Name: name, Command: "run",
 	}); err != nil {
 		t.Fatalf("create mcp %s: %v", name, err)
+	}
+}
+
+func mustCreateInitScript(ctx context.Context, t *testing.T, server *Server, environmentID, script string) {
+	t.Helper()
+	if _, err := server.CreateInitScript(ctx, &agentsv1.CreateInitScriptRequest{
+		Target: &agentsv1.CreateInitScriptRequest_EnvironmentId{EnvironmentId: environmentID},
+		Script: script,
+	}); err != nil {
+		t.Fatalf("create init script %q: %v", script, err)
 	}
 }
 

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -29,7 +29,7 @@ func (s *Store) CreateEnvironment(ctx context.Context, organizationID uuid.UUID,
 		input.AgentRuntimeImageTag,
 		input.Availability,
 		input.LLMMode,
-		input.LLMAllowedModels,
+		nonNilStrings(input.LLMAllowedModels),
 	)
 	environment, err := scanEnvironment(row)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1122,11 +1122,7 @@ func (s *Store) CreateInitScript(ctx context.Context, organizationID uuid.UUID, 
 			}
 			return InitScript{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, script.AgentID, script.McpID)
-		if err != nil {
-			return InitScript{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
 			return InitScript{}, err
 		}
 		return script, nil
@@ -1170,11 +1166,7 @@ func (s *Store) UpdateInitScript(ctx context.Context, id uuid.UUID, update InitS
 			}
 			return InitScript{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, script.AgentID, script.McpID)
-		if err != nil {
-			return InitScript{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
 			return InitScript{}, err
 		}
 		return script, nil
@@ -1194,11 +1186,7 @@ func (s *Store) DeleteInitScript(ctx context.Context, id uuid.UUID) error {
 			}
 			return struct{}{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, script.AgentID, script.McpID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -1214,6 +1202,9 @@ func (s *Store) ListInitScripts(ctx context.Context, filter InitScriptFilter, pa
 	}
 	if filter.McpID != nil {
 		clauses, args = appendClause(clauses, args, "mcp_id = $%d", *filter.McpID)
+	}
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
 	}
 
 	scripts, nextCursor, err := listEntities(ctx, s.pool,


### PR DESCRIPTION
Three defects in the init-scripts path left by #86, found while auditing authorization. None of them is an authorization check — the checks are a separate PR — but the first one defeats the check that already exists.

### The listing ignored the environment

`store.ListInitScripts` built its `WHERE` from `agent_id` and `mcp_id` only. The handler sets `filter.EnvironmentID` and authorizes `can_read_config` on that environment first, so the check passes and the query then returns **every init script in the database** — every organization, every parent kind. There is no organization clause either, so nothing else narrows it.

### No init script on an environment could be written

`CreateInitScript`, `UpdateInitScript` and `DeleteInitScript` resolved the agent to touch through `resolveAgentID`, which understands `agent_id` and `mcp_id` and returns `missing target identifier` for anything else. An environment-parented row therefore failed the whole transaction — environment-scoped init scripts have never worked. The ENV family already routes through `touchTargetAgent`, which returns early for an environment; these three now do the same.

### CreateEnvironment sent a nil slice to a NOT NULL column

`llm_allowed_models` is NOT NULL. The handler normalises to `{}`; the store did not, so every other caller failed. Normalised with the `nonNilStrings` helper this file already applies to `shared_volumes`.

### Verification

Against a real Postgres (`AGENTS_TEST_DATABASE_URL`), `TestEnvironmentScopedListsAreScoped` now creates init scripts on two environments and asserts the filter narrows. Each bug is independently covered:

- without the writer fix: `create init script "echo first": missing target identifier`
- with the writer fix but without the filter: `expected only the first environment's script, got 2`
- with both: green

Four database tests were already failing on `main` for the NOT NULL and `llm_mode` reasons above; `./internal/...` is now green with a database attached. They skip silently without one, which is why none of this was visible.