### PR TITLE
Admit the platform to the reads it needs, and publish where it listens

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -16,6 +16,11 @@ import (
 const (
 	identityPrefix      = "identity:"
 	organizationPrefix  = "organization:"
+	// The platform's own identity, and the relation that settles its claim. The
+	// type is metadata and proves nothing on its own.
+	platformIdentityType = "platform"
+	clusterAdminRelation = "admin"
+	clusterObject        = "cluster:global"
 	agentPrefix         = "agent:"
 	agentInstancePrefix = "agent_instance:"
 	sandboxPrefix       = "sandbox:"
@@ -662,4 +667,12 @@ func sandboxOwnerTuple(sandboxID uuid.UUID, ownerID uuid.UUID) *authorizationv1.
 		Relation: "owner",
 		Object:   sandboxPrefix + sandboxID.String(),
 	}
+}
+
+func identityTypeFromContext(ctx context.Context) string {
+	identityType, ok := metadataValueFromIncomingContext(ctx, "x-identity-type")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(identityType)
 }

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -450,3 +450,56 @@ func TestGetSandboxServesTheInternalCallerWithoutAnIdentity(t *testing.T) {
 		t.Fatal("expected no identity for an internal caller")
 	}
 }
+
+// The Orchestrator reads an instance's inbox to learn which thread it was
+// handed work for. It used to send that instance's own id as the caller; as
+// itself it carries cluster admin, and that is what admits it.
+func TestSelfInstanceOrPlatformAdmitsClusterAdmin(t *testing.T) {
+	platformID := uuid.New()
+	instanceID := uuid.New()
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"x-identity-id", platformID.String(),
+		"x-identity-type", "platform",
+	))
+
+	if err := server.requireSelfInstanceOrPlatform(ctx, instanceID); err != nil {
+		t.Fatalf("expected the platform to be admitted: %v", err)
+	}
+}
+
+// Claiming the type is not holding the relation.
+func TestSelfInstanceOrPlatformRefusesPlatformWithoutClusterAdmin(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{deniedRelations: map[string]bool{"admin": true}}}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"x-identity-id", uuid.New().String(),
+		"x-identity-type", "platform",
+	))
+
+	if err := server.requireSelfInstanceOrPlatform(ctx, uuid.New()); err == nil {
+		t.Fatal("expected a caller without cluster admin to be refused")
+	}
+}
+
+// Another instance is still another instance, whatever it says it is.
+func TestSelfInstanceOrPlatformRefusesAnotherInstance(t *testing.T) {
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"x-identity-id", uuid.New().String(),
+		"x-identity-type", "agent_instance",
+	))
+
+	if err := server.requireSelfInstanceOrPlatform(ctx, uuid.New()); err == nil {
+		t.Fatal("expected one instance reading another's inbox to be refused")
+	}
+}
+
+func TestSelfInstanceOrPlatformAdmitsTheInstanceItself(t *testing.T) {
+	instanceID := uuid.New()
+	server := &Server{authz: &recordingAuthorizationWriter{}}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", instanceID.String()))
+
+	if err := server.requireSelfInstanceOrPlatform(ctx, instanceID); err != nil {
+		t.Fatalf("expected the instance itself to be admitted: %v", err)
+	}
+}

--- a/internal/server/instances.go
+++ b/internal/server/instances.go
@@ -459,7 +459,7 @@ func (s *Server) GetUnackedInboxItems(ctx context.Context, req *agentsv1.GetUnac
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "agent_instance_id: %v", err)
 	}
-	if err := requireSelfInstance(ctx, instanceID); err != nil {
+	if err := s.requireSelfInstanceOrPlatform(ctx, instanceID); err != nil {
 		return nil, err
 	}
 	cursor, err := decodeInboxPageCursor(req.GetPageToken())
@@ -571,7 +571,7 @@ func (s *Server) GetUnackedInboxCount(ctx context.Context, req *agentsv1.GetUnac
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "agent_instance_id: %v", err)
 	}
-	if err := requireSelfInstance(ctx, instanceID); err != nil {
+	if err := s.requireSelfInstanceOrPlatform(ctx, instanceID); err != nil {
 		return nil, err
 	}
 	var threadID *uuid.UUID
@@ -662,6 +662,38 @@ func requireSelfInstance(ctx context.Context, instanceID uuid.UUID) error {
 	}
 	if identityID != instanceID.String() {
 		return status.Error(codes.PermissionDenied, "caller must be the agent instance")
+	}
+	return nil
+}
+
+// requireSelfInstanceOrPlatform admits the instance itself, or the platform.
+//
+// The Orchestrator has to know which thread an instance was handed work for
+// before it can place a workload to do it, and it is not that instance. It used
+// to send the instance's own id as the caller to get past the check above,
+// which is a platform service claiming to be the thing it manages. As itself it
+// carries cluster admin, and that is what admits it here.
+//
+// Reads only. Acking is the instance saying it has handled its own message and
+// stays exactly that -- see AckInboxItems, which keeps requireSelfInstance.
+func (s *Server) requireSelfInstanceOrPlatform(ctx context.Context, instanceID uuid.UUID) error {
+	selfErr := requireSelfInstance(ctx, instanceID)
+	if selfErr == nil {
+		return nil
+	}
+	if identityTypeFromContext(ctx) != platformIdentityType {
+		return selfErr
+	}
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return selfErr
+	}
+	callerID, err := uuid.Parse(identityID)
+	if err != nil {
+		return selfErr
+	}
+	if err := s.requireAllowed(ctx, callerID, clusterAdminRelation, clusterObject, selfErr); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -115,6 +115,10 @@ func (s *Server) publishSandboxUpdated(ctx context.Context, sandbox store.Sandbo
 			// viewer who is not the owner -- the detail view of a sandbox an
 			// organization owner did not create.
 			fmt.Sprintf("sandbox:%s", sandbox.Meta.ID),
+			// The three above are views someone opened. This one is the
+			// platform's, and it is the only one that reaches a reconciler
+			// which cannot know an organization exists until it is told.
+			platformSandboxesRoom,
 		},
 		Payload: payload,
 		Source:  "agents",
@@ -169,6 +173,12 @@ func (s *Server) publishAgentUpdatedForTarget(ctx context.Context, agentID *uuid
 const (
 	instanceUpdatedEvent  = "instance.updated"
 	inboxItemCreatedEvent = "message.created"
+	// Cluster-wide rooms, held by the platform alone. Every other room here is
+	// keyed by the entity someone is looking at; these are keyed by nothing,
+	// because the Orchestrator reconciles all of them and a room set it has to
+	// derive is one that misses whatever it has not seen yet.
+	platformAgentInstancesRoom = "agent_instances"
+	platformSandboxesRoom      = "sandboxes"
 )
 
 func (s *Server) publishInstanceUpdated(ctx context.Context, instance store.AgentInstance) {
@@ -183,8 +193,14 @@ func (s *Server) publishInstanceUpdated(ctx context.Context, instance store.Agen
 		return
 	}
 	_, err = s.notifications.Publish(ctx, &notificationsv1.PublishRequest{
-		Event:   instanceUpdatedEvent,
-		Rooms:   []string{fmt.Sprintf("agent_instance:%s", instance.Meta.ID)},
+		Event: instanceUpdatedEvent,
+		Rooms: []string{
+			fmt.Sprintf("agent_instance:%s", instance.Meta.ID),
+			// The cluster-wide room the Orchestrator holds. It reconciles every
+			// instance there is, so it cannot be made to subscribe per instance
+			// without racing the creation of the next one.
+			platformAgentInstancesRoom,
+		},
 		Payload: payload,
 		Source:  "agents",
 	})
@@ -204,8 +220,16 @@ func (s *Server) publishInboxItemCreated(ctx context.Context, item store.InboxIt
 		return
 	}
 	_, err = s.notifications.Publish(ctx, &notificationsv1.PublishRequest{
-		Event:   inboxItemCreatedEvent,
-		Rooms:   []string{fmt.Sprintf("instance_inbox:%s", item.AgentInstanceID)},
+		Event: inboxItemCreatedEvent,
+		Rooms: []string{
+			fmt.Sprintf("instance_inbox:%s", item.AgentInstanceID),
+			// The Orchestrator has to start a workload for an instance that has
+			// work waiting, and the inbox room is the instance's own -- it reads
+			// what arrived, not merely that something did. The platform room
+			// carries the same wake without the contents: this payload is ids
+			// and a source kind, nothing of the message itself.
+			platformAgentInstancesRoom,
+		},
 		Payload: payload,
 		Source:  "agents",
 	})

--- a/internal/server/notifications_test.go
+++ b/internal/server/notifications_test.go
@@ -48,6 +48,7 @@ func TestPublishSandboxUpdatedIncludesSnapshotPayload(t *testing.T) {
 		"sandbox_owner:" + sandbox.OwnerID.String(),
 		"sandbox_org:" + sandbox.OrganizationID.String(),
 		"sandbox:" + sandbox.Meta.ID.String(),
+		"sandboxes",
 	})
 	fields := request.GetPayload().GetFields()
 	assertStringField(t, fields, "sandbox_id", sandbox.Meta.ID.String())
@@ -113,6 +114,61 @@ func TestSandboxRuntimeStateUpdatedResponsePublishesNotification(t *testing.T) {
 	}
 	fields := notifications.published[0].GetPayload().GetFields()
 	assertStringField(t, fields, "status", string(store.SandboxStatusStopped))
+}
+
+// Every instance lifecycle event reaches the cluster-wide room as well as the
+// instance's own. Without it the Orchestrator would have to subscribe per
+// instance, which cannot cover an instance created after it last looked.
+func TestPublishInstanceUpdatedReachesThePlatformRoom(t *testing.T) {
+	notifications := &recordingNotificationsClient{}
+	server := &Server{notifications: notifications}
+	instance := store.AgentInstance{
+		Meta:           store.EntityMeta{ID: uuid.New()},
+		AgentID:        uuid.New(),
+		OrganizationID: uuid.New(),
+		State:          store.AgentInstanceStateActive,
+	}
+
+	server.publishInstanceUpdated(context.Background(), instance)
+
+	if len(notifications.published) != 1 {
+		t.Fatalf("expected 1 publish request, got %d", len(notifications.published))
+	}
+	assertRooms(t, notifications.published[0].GetRooms(), []string{
+		"agent_instance:" + instance.Meta.ID.String(),
+		"agent_instances",
+	})
+}
+
+// The instance is woken through its own inbox room; the Orchestrator is woken
+// through the cluster-wide room. Dropping the second leaves an instance with
+// work waiting and no workload to do it until the next reconcile tick.
+func TestPublishInboxItemCreatedReachesTheInstanceAndThePlatform(t *testing.T) {
+	notifications := &recordingNotificationsClient{}
+	server := &Server{notifications: notifications}
+	item := store.InboxItem{
+		ID:              uuid.New(),
+		AgentInstanceID: uuid.New(),
+		SourceKind:      store.InboxItemSourceKindThread,
+	}
+
+	server.publishInboxItemCreated(context.Background(), item)
+
+	if len(notifications.published) != 1 {
+		t.Fatalf("expected 1 publish request, got %d", len(notifications.published))
+	}
+	request := notifications.published[0]
+	if request.GetEvent() != inboxItemCreatedEvent {
+		t.Fatalf("expected event %q, got %q", inboxItemCreatedEvent, request.GetEvent())
+	}
+	assertRooms(t, request.GetRooms(), []string{
+		"instance_inbox:" + item.AgentInstanceID.String(),
+		"agent_instances",
+	})
+	fields := request.GetPayload().GetFields()
+	assertStringField(t, fields, "inbox_item_id", item.ID.String())
+	assertStringField(t, fields, "agent_instance_id", item.AgentInstanceID.String())
+	assertStringField(t, fields, "source_kind", string(item.SourceKind))
 }
 
 type recordingNotificationsClient struct {


### PR DESCRIPTION
agents-orchestrator 0.20.0 stopped borrowing an agent instance's identity to call platform services. That is the right change, but it left the Orchestrator with no way through two paths here, and the local VM has been failing its reconcile loop every 5s since the bump:

```
reconciler: cycle failed: get first unacked inbox item for agent instance 35c4ae64-...:
  rpc error: code = PermissionDenied desc = caller must be the agent instance
```

**Inbox reads.** The Orchestrator has to know which thread an instance was handed work for before it can place a workload to do it, and it is not that instance. `GetUnackedInboxItems` and `GetUnackedInboxCount` now admit a caller carrying `admin` on `cluster:global` as well as the instance itself. The identity type is metadata and proves nothing on its own -- the OpenFGA check is what admits it.

Reads only. `AckInboxItems` keeps `requireSelfInstance`: acking is the instance saying it has handled its own message and stays exactly that.

**Publishing.** Instance and inbox updates now also go to `agent_instances`, and sandbox updates to `sandboxes` -- the cluster-wide rooms the Orchestrator holds since 0.20.0. Without this it subscribes and hears nothing, falling back to its poll tick. It reconciles every instance and sandbox there is, so a room set it has to derive is one that misses whatever it has not enumerated yet.

Verified on top of `main`: builds, vets, and `internal/server` passes, including the four new `SelfInstanceOrPlatform` cases and the room-publishing tests.