### PR TITLE
Write the sandbox holder's authorization chain

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -528,19 +528,23 @@ func (s *Server) removeAgentInstanceAuthorization(ctx context.Context, instance 
 	})
 }
 
-func (s *Server) addSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID) error {
+func (s *Server) addSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID, environmentID uuid.UUID) error {
 	return s.writeAuthorization(ctx, []*authorizationv1.TupleKey{
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
 		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
+		sandboxHolderIdentityTuple(sandboxID),
+		sandboxEnvironmentTuple(sandboxID, environmentID),
 	}, nil)
 }
 
-func (s *Server) removeSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID) error {
+func (s *Server) removeSandboxAuthorization(ctx context.Context, sandboxID uuid.UUID, organizationID uuid.UUID, ownerID uuid.UUID, environmentID uuid.UUID) error {
 	return s.writeAuthorization(ctx, nil, []*authorizationv1.TupleKey{
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
 		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
+		sandboxHolderIdentityTuple(sandboxID),
+		sandboxEnvironmentTuple(sandboxID, environmentID),
 	})
 }
 
@@ -666,6 +670,29 @@ func sandboxOwnerTuple(sandboxID uuid.UUID, ownerID uuid.UUID) *authorizationv1.
 		User:     identityPrefix + ownerID.String(),
 		Relation: "owner",
 		Object:   sandboxPrefix + sandboxID.String(),
+	}
+}
+
+// sandboxHolderIdentityTuple names the identity the sandbox workload
+// authenticates as, which is how it reads the environment it was started from.
+// Distinct from the owner: the workload holds this for its whole life, and the
+// person who started it is not who is asking.
+func sandboxHolderIdentityTuple(sandboxID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     identityPrefix + sandboxID.String(),
+		Relation: "holder",
+		Object:   sandboxPrefix + sandboxID.String(),
+	}
+}
+
+// sandboxEnvironmentTuple reaches the environment's config from the sandboxes
+// started in it, so a holder reads the init scripts it must run. The mirror of
+// agentEnvironmentTuple, for the workload that carries no agent.
+func sandboxEnvironmentTuple(sandboxID uuid.UUID, environmentID uuid.UUID) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     sandboxPrefix + sandboxID.String(),
+		Relation: "sandbox",
+		Object:   environmentPrefix + environmentID.String(),
 	}
 }
 

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -98,8 +98,9 @@ func TestAddSandboxAuthorizationWritesOrgAndOwner(t *testing.T) {
 	sandboxID := uuid.New()
 	organizationID := uuid.New()
 	ownerID := uuid.New()
+	environmentID := uuid.New()
 
-	if err := server.addSandboxAuthorization(context.Background(), sandboxID, organizationID, ownerID); err != nil {
+	if err := server.addSandboxAuthorization(context.Background(), sandboxID, organizationID, ownerID, environmentID); err != nil {
 		t.Fatalf("add sandbox authorization: %v", err)
 	}
 
@@ -108,8 +109,55 @@ func TestAddSandboxAuthorizationWritesOrgAndOwner(t *testing.T) {
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
 		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
+		sandboxHolderIdentityTuple(sandboxID),
+		sandboxEnvironmentTuple(sandboxID, environmentID),
 	})
 	assertTuples(t, request.GetDeletes(), nil)
+}
+
+// The holder chain is what lets the workload read the init scripts it must
+// run, so assert the literal tuples rather than re-deriving them.
+func TestSandboxHolderReachesItsEnvironmentConfig(t *testing.T) {
+	authz := &recordingAuthorizationWriter{}
+	server := &Server{authz: authz}
+	sandboxID := uuid.New()
+	environmentID := uuid.New()
+
+	if err := server.addSandboxAuthorization(context.Background(), sandboxID, uuid.New(), uuid.New(), environmentID); err != nil {
+		t.Fatalf("add sandbox authorization: %v", err)
+	}
+
+	writes := singleWriteRequest(t, authz).GetWrites()
+	holder := tupleWithRelation(writes, "holder")
+	if holder == nil {
+		t.Fatal("expected the sandbox workload to be written as its own holder")
+	}
+	if holder.GetUser() != "identity:"+sandboxID.String() {
+		t.Fatalf("expected the sandbox's own identity, got %q", holder.GetUser())
+	}
+	if holder.GetObject() != "sandbox:"+sandboxID.String() {
+		t.Fatalf("expected the holder tuple on the sandbox, got %q", holder.GetObject())
+	}
+
+	environment := tupleWithRelation(writes, "sandbox")
+	if environment == nil {
+		t.Fatal("expected the sandbox to be written onto its environment")
+	}
+	if environment.GetUser() != "sandbox:"+sandboxID.String() {
+		t.Fatalf("expected the sandbox as the user, got %q", environment.GetUser())
+	}
+	if environment.GetObject() != "environment:"+environmentID.String() {
+		t.Fatalf("expected the sandbox's own environment, got %q", environment.GetObject())
+	}
+}
+
+func tupleWithRelation(tuples []*authorizationv1.TupleKey, relation string) *authorizationv1.TupleKey {
+	for _, tuple := range tuples {
+		if tuple.GetRelation() == relation {
+			return tuple
+		}
+	}
+	return nil
 }
 
 // The workload's access comes from this tuple, not from its identity type, so
@@ -120,16 +168,11 @@ func TestSandboxIdentityBecomesOrganizationMember(t *testing.T) {
 	sandboxID := uuid.New()
 	organizationID := uuid.New()
 
-	if err := server.addSandboxAuthorization(context.Background(), sandboxID, organizationID, uuid.New()); err != nil {
+	if err := server.addSandboxAuthorization(context.Background(), sandboxID, organizationID, uuid.New(), uuid.New()); err != nil {
 		t.Fatalf("add sandbox authorization: %v", err)
 	}
 
-	var found *authorizationv1.TupleKey
-	for _, tuple := range singleWriteRequest(t, authz).GetWrites() {
-		if tuple.GetRelation() == "member" {
-			found = tuple
-		}
-	}
+	found := tupleWithRelation(singleWriteRequest(t, authz).GetWrites(), "member")
 	if found == nil {
 		t.Fatal("expected the sandbox workload to be written as an organization member")
 	}
@@ -147,8 +190,9 @@ func TestRemoveSandboxAuthorizationDeletesOrgAndOwner(t *testing.T) {
 	sandboxID := uuid.New()
 	organizationID := uuid.New()
 	ownerID := uuid.New()
+	environmentID := uuid.New()
 
-	if err := server.removeSandboxAuthorization(context.Background(), sandboxID, organizationID, ownerID); err != nil {
+	if err := server.removeSandboxAuthorization(context.Background(), sandboxID, organizationID, ownerID, environmentID); err != nil {
 		t.Fatalf("remove sandbox authorization: %v", err)
 	}
 
@@ -158,6 +202,8 @@ func TestRemoveSandboxAuthorizationDeletesOrgAndOwner(t *testing.T) {
 		sandboxOrganizationTuple(sandboxID, organizationID),
 		sandboxOwnerTuple(sandboxID, ownerID),
 		sandboxIdentityOrganizationMembershipTuple(sandboxID, organizationID),
+		sandboxHolderIdentityTuple(sandboxID),
+		sandboxEnvironmentTuple(sandboxID, environmentID),
 	})
 }
 

--- a/internal/server/sandbox.go
+++ b/internal/server/sandbox.go
@@ -335,7 +335,7 @@ func (s *Server) CreateSandbox(ctx context.Context, req *agentsv1.CreateSandboxR
 	if err != nil {
 		return nil, toStatusError(err)
 	}
-	if err := s.addSandboxAuthorization(ctx, sandbox.Meta.ID, sandbox.OrganizationID, sandbox.OwnerID); err != nil {
+	if err := s.addSandboxAuthorization(ctx, sandbox.Meta.ID, sandbox.OrganizationID, sandbox.OwnerID, sandbox.EnvironmentID); err != nil {
 		if rollbackErr := s.store.DeleteSandboxRecord(ctx, sandbox.Meta.ID); rollbackErr != nil {
 			return nil, status.Errorf(codes.Internal, "authorization failed: %v; rollback failed: %v", err, rollbackErr)
 		}


### PR DESCRIPTION
A sandbox workload authenticates as its own sandbox id and held only `member` on the organization, so it could not read the environment it was started in — and `agynd` in holder mode never got the init scripts it is supposed to run.

Creation now writes the two tuples that resolve `holder from sandbox` on the environment: the workload's identity as `holder` of its sandbox, and the sandbox as `sandbox` of its environment. The mirror of the `agent`/`instance` pair agent workloads already get.

Needs agynio/authorization#42 live first — OpenFGA rejects tuples whose relations the active model does not define.

Sandboxes created before this land hold no holder tuple and keep failing until recreated.