### PR TITLE
Refuse an agent that has no agent CLI to run

### DIFF
--- a/internal/server/agent_environment_test.go
+++ b/internal/server/agent_environment_test.go
@@ -45,27 +45,47 @@ func agentEnvironmentServer(ctx context.Context, t *testing.T) *Server {
 	return New(store.New(pool), noopAuthorizationWriter{}, noopIdentityWriter{}, noopNotificationsClient{})
 }
 
+// createTestEnvironment builds one an agent can run in: it names an agent
+// runtime image, which is where the agent CLI comes from.
 func createTestEnvironment(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, name string) string {
 	t.Helper()
-	response, err := server.CreateEnvironment(ctx, &agentsv1.CreateEnvironmentRequest{
+	return createEnvironmentWithRuntime(ctx, t, server, organizationID, name, true)
+}
+
+// createWorkspaceOnlyEnvironment builds one only a sandbox can use: a sandbox
+// brings its own tooling, so it needs no agent runtime image.
+func createWorkspaceOnlyEnvironment(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, name string) string {
+	t.Helper()
+	return createEnvironmentWithRuntime(ctx, t, server, organizationID, name, false)
+}
+
+func createEnvironmentWithRuntime(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, name string, withRuntime bool) string {
+	t.Helper()
+	request := &agentsv1.CreateEnvironmentRequest{
 		OrganizationId: organizationID.String(),
 		RunnerId:       uuid.NewString(),
 		Name:           name,
 		Image:          "ghcr.io/agynio/environment:latest",
 		Flavor:         "small",
 		Availability:   agentsv1.EnvironmentAvailability_ENVIRONMENT_AVAILABILITY_INTERNAL,
-	})
+	}
+	if withRuntime {
+		request.AgentRuntimeImageId = uuid.NewString()
+		request.AgentRuntimeImageTag = "1.0.0"
+	}
+	response, err := server.CreateEnvironment(ctx, request)
 	if err != nil {
 		t.Fatalf("create environment: %v", err)
 	}
 	return response.GetEnvironment().GetMeta().GetId()
 }
 
-func createAgentRequest(organizationID uuid.UUID, name string) *agentsv1.CreateAgentRequest {
+func createAgentRequest(organizationID uuid.UUID, name, environmentID string) *agentsv1.CreateAgentRequest {
 	return &agentsv1.CreateAgentRequest{
 		OrganizationId: organizationID.String(),
 		Name:           name,
 		Model:          uuid.NewString(),
+		EnvironmentId:  environmentID,
 		InitImage:      testInitImage,
 		Availability:   agentsv1.AgentAvailability_AGENT_AVAILABILITY_INTERNAL,
 	}
@@ -79,9 +99,7 @@ func TestCreateAgentPersistsTheEnvironmentReference(t *testing.T) {
 	organizationID := uuid.New()
 	environmentID := createTestEnvironment(ctx, t, server, organizationID, "default")
 
-	request := createAgentRequest(organizationID, "alpha")
-	request.EnvironmentId = environmentID
-	created, err := server.CreateAgent(ctx, request)
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", environmentID))
 	if err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -110,27 +128,44 @@ func TestCreateAgentPersistsTheEnvironmentReference(t *testing.T) {
 	}
 }
 
-// The reference is optional: agents created before environments existed have
-// none, and one can still be created without naming an environment.
-func TestCreateAgentWithoutAnEnvironmentLeavesItEmpty(t *testing.T) {
+// An agent takes its CLI from its environment's agent runtime image, so an agent
+// with no environment has no CLI to run. The Orchestrator refuses to assemble
+// one, on every cycle, forever -- so the refusal belongs here, where the caller
+// hears it.
+func TestCreateAgentRequiresAnEnvironment(t *testing.T) {
+	ctx := identityContext(uuid.New())
+	server := agentEnvironmentServer(ctx, t)
+
+	_, err := server.CreateAgent(ctx, createAgentRequest(uuid.New(), "alpha", ""))
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument, got %v", err)
+	}
+}
+
+// A workspace-only environment is one a sandbox uses. It names no agent runtime
+// image, so it leaves an agent in exactly the state above.
+func TestAgentRefusesAWorkspaceOnlyEnvironment(t *testing.T) {
 	ctx := identityContext(uuid.New())
 	server := agentEnvironmentServer(ctx, t)
 	organizationID := uuid.New()
+	runnable := createTestEnvironment(ctx, t, server, organizationID, "runnable")
+	workspaceOnly := createWorkspaceOnlyEnvironment(ctx, t, server, organizationID, "sandboxes")
 
-	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+	_, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", workspaceOnly))
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected failed precondition on create, got %v", err)
+	}
+
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "beta", runnable))
 	if err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
-	if created.GetAgent().GetEnvironmentId() != "" {
-		t.Fatalf("expected no environment on the created agent, got %q", created.GetAgent().GetEnvironmentId())
-	}
-
-	fetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: created.GetAgent().GetMeta().GetId()})
-	if err != nil {
-		t.Fatalf("get agent: %v", err)
-	}
-	if fetched.GetAgent().GetEnvironmentId() != "" {
-		t.Fatalf("expected no environment on the fetched agent, got %q", fetched.GetAgent().GetEnvironmentId())
+	_, err = server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
+		Id:            created.GetAgent().GetMeta().GetId(),
+		EnvironmentId: ptr(workspaceOnly),
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected failed precondition on update, got %v", err)
 	}
 }
 
@@ -148,9 +183,7 @@ func TestAgentRefusesAnEnvironmentFromAnotherOrganization(t *testing.T) {
 		{
 			name: "create",
 			refuse: func(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, environmentID string) error {
-				request := createAgentRequest(organizationID, "alpha")
-				request.EnvironmentId = environmentID
-				_, err := server.CreateAgent(ctx, request)
+				_, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", environmentID))
 				return err
 			},
 		},
@@ -158,7 +191,8 @@ func TestAgentRefusesAnEnvironmentFromAnotherOrganization(t *testing.T) {
 			name: "update",
 			refuse: func(ctx context.Context, t *testing.T, server *Server, organizationID uuid.UUID, environmentID string) error {
 				t.Helper()
-				created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+				own := createTestEnvironment(ctx, t, server, organizationID, "own")
+				created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", own))
 				if err != nil {
 					t.Fatalf("create agent: %v", err)
 				}
@@ -190,16 +224,17 @@ func TestAgentRefusesAnEnvironmentFromAnotherOrganization(t *testing.T) {
 	}
 }
 
-// An agent may move to an environment it did not name at creation, and may give
-// one up again — an agent with none is the state every agent was in before
-// environments existed.
-func TestUpdateAgentSetsAndClearsTheEnvironmentReference(t *testing.T) {
+// An agent may move to an environment it did not name at creation. It may not
+// give one up: an empty environment_id used to clear the reference, and now
+// leaves the agent in the state CreateAgent refuses to produce.
+func TestUpdateAgentMovesTheEnvironmentAndRefusesToClearIt(t *testing.T) {
 	ctx := identityContext(uuid.New())
 	server := agentEnvironmentServer(ctx, t)
 	organizationID := uuid.New()
-	environmentID := createTestEnvironment(ctx, t, server, organizationID, "default")
+	first := createTestEnvironment(ctx, t, server, organizationID, "first")
+	second := createTestEnvironment(ctx, t, server, organizationID, "second")
 
-	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", first))
 	if err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -207,40 +242,36 @@ func TestUpdateAgentSetsAndClearsTheEnvironmentReference(t *testing.T) {
 
 	updated, err := server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
 		Id:            agentID,
-		EnvironmentId: ptr(environmentID),
+		EnvironmentId: ptr(second),
 	})
 	if err != nil {
 		t.Fatalf("update agent: %v", err)
 	}
-	if updated.GetAgent().GetEnvironmentId() != environmentID {
-		t.Fatalf("expected environment %s after the update, got %q", environmentID, updated.GetAgent().GetEnvironmentId())
+	if updated.GetAgent().GetEnvironmentId() != second {
+		t.Fatalf("expected environment %s after the update, got %q", second, updated.GetAgent().GetEnvironmentId())
 	}
 
 	fetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
 	if err != nil {
 		t.Fatalf("get agent: %v", err)
 	}
-	if fetched.GetAgent().GetEnvironmentId() != environmentID {
-		t.Fatalf("expected environment %s to be stored, got %q", environmentID, fetched.GetAgent().GetEnvironmentId())
+	if fetched.GetAgent().GetEnvironmentId() != second {
+		t.Fatalf("expected environment %s to be stored, got %q", second, fetched.GetAgent().GetEnvironmentId())
 	}
 
-	cleared, err := server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
+	if _, err := server.UpdateAgent(ctx, &agentsv1.UpdateAgentRequest{
 		Id:            agentID,
 		EnvironmentId: ptr(""),
-	})
-	if err != nil {
-		t.Fatalf("clear environment: %v", err)
-	}
-	if cleared.GetAgent().GetEnvironmentId() != "" {
-		t.Fatalf("expected no environment after clearing, got %q", cleared.GetAgent().GetEnvironmentId())
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected clearing to be refused, got %v", err)
 	}
 
 	refetched, err := server.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: agentID})
 	if err != nil {
 		t.Fatalf("get agent: %v", err)
 	}
-	if refetched.GetAgent().GetEnvironmentId() != "" {
-		t.Fatalf("expected the cleared environment to be stored, got %q", refetched.GetAgent().GetEnvironmentId())
+	if refetched.GetAgent().GetEnvironmentId() != second {
+		t.Fatalf("expected environment %s to survive the refusal, got %q", second, refetched.GetAgent().GetEnvironmentId())
 	}
 }
 
@@ -251,8 +282,7 @@ func TestAgentRefusesAnUnknownEnvironment(t *testing.T) {
 	server := agentEnvironmentServer(ctx, t)
 	organizationID := uuid.New()
 
-	request := createAgentRequest(organizationID, "alpha")
-	request.EnvironmentId = uuid.NewString()
+	request := createAgentRequest(organizationID, "alpha", uuid.NewString())
 	if _, err := server.CreateAgent(ctx, request); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("expected invalid argument, got %v", err)
 	}
@@ -262,8 +292,7 @@ func TestCreateAgentRejectsAMalformedEnvironment(t *testing.T) {
 	ctx := identityContext(uuid.New())
 	server := agentEnvironmentServer(ctx, t)
 
-	request := createAgentRequest(uuid.New(), "alpha")
-	request.EnvironmentId = "not-a-uuid"
+	request := createAgentRequest(uuid.New(), "alpha", "not-a-uuid")
 	if _, err := server.CreateAgent(ctx, request); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("expected invalid argument, got %v", err)
 	}
@@ -276,8 +305,9 @@ func TestUpdateAgentAcceptsTheEnvironmentAsTheOnlyField(t *testing.T) {
 	server := agentEnvironmentServer(ctx, t)
 	organizationID := uuid.New()
 	environmentID := createTestEnvironment(ctx, t, server, organizationID, "default")
+	other := createTestEnvironment(ctx, t, server, organizationID, "other")
 
-	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha"))
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", other))
 	if err != nil {
 		t.Fatalf("create agent: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,41 +131,59 @@ func (s *Server) removeAgentNickname(ctx context.Context, agentID uuid.UUID, org
 // environment in another organization. The composite foreign key on agents
 // refuses that too, but the violation would reach the caller as an opaque
 // internal error rather than naming the field that was wrong.
-func (s *Server) environmentInOrganization(ctx context.Context, value string, organizationID uuid.UUID) (uuid.UUID, error) {
+func (s *Server) environmentInOrganization(ctx context.Context, value string, organizationID uuid.UUID) (uuid.UUID, store.Environment, error) {
 	environmentID, err := parseUUID(value)
 	if err != nil {
-		return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+		return uuid.UUID{}, store.Environment{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 	}
 	environment, err := s.store.GetEnvironment(ctx, environmentID)
 	if err != nil {
 		var notFound *store.NotFoundError
 		if errors.As(err, &notFound) {
-			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
+			return uuid.UUID{}, store.Environment{}, status.Errorf(codes.InvalidArgument, "environment_id: %v", err)
 		}
-		return uuid.UUID{}, toStatusError(err)
+		return uuid.UUID{}, store.Environment{}, toStatusError(err)
 	}
 	if environment.OrganizationID != organizationID {
-		return uuid.UUID{}, status.Error(codes.InvalidArgument, "environment_id: environment belongs to another organization")
+		return uuid.UUID{}, store.Environment{}, status.Error(codes.InvalidArgument, "environment_id: environment belongs to another organization")
 	}
 	// Pointing an agent at an environment runs its workloads there, reaching the
 	// same secrets, egress credentials and volume contents a sandbox would, so
 	// it takes the same grant.
 	if err := s.requireEnvironmentUse(ctx, environmentID); err != nil {
-		return uuid.UUID{}, err
+		return uuid.UUID{}, store.Environment{}, err
 	}
-	return environmentID, nil
+	return environmentID, environment, nil
+}
+
+// agentEnvironment resolves the environment an agent is being pointed at, and
+// refuses one it could not run in.
+//
+// Naming none at all, or naming one with no agent runtime image, both leave the
+// agent without a CLI: init_image no longer stands in for one. The Orchestrator
+// refuses to assemble a workload without a runtime, so such an agent is retried
+// every reconcile cycle and never starts -- a failure only the Orchestrator's
+// own log ever sees.
+func (s *Server) agentEnvironment(ctx context.Context, value string, organizationID uuid.UUID) (uuid.UUID, store.Environment, error) {
+	if value == "" {
+		return uuid.UUID{}, store.Environment{}, status.Error(codes.InvalidArgument,
+			"environment_id is required: an agent takes its agent CLI from an environment's agent runtime image")
+	}
+	environmentID, environment, err := s.environmentInOrganization(ctx, value, organizationID)
+	if err != nil {
+		return uuid.UUID{}, store.Environment{}, err
+	}
+	if environment.AgentRuntimeImageID == nil {
+		return uuid.UUID{}, store.Environment{}, status.Errorf(codes.FailedPrecondition,
+			"environment %s names no agent runtime image, so it has no agent CLI to run", environment.Name)
+	}
+	return environmentID, environment, nil
 }
 
 func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentRequest) (*agentsv1.CreateAgentResponse, error) {
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-	}
-	// init_image is required only for the deprecated inline path. An agent
-	// running an environment takes its agent CLI from that environment's agent
-	// runtime image instead.
-	if req.GetInitImage() == "" && req.GetEnvironmentId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "init_image is required when no environment is named")
 	}
 	availability, err := agentAvailabilityFromProto(req.GetAvailability())
 	if err != nil {
@@ -197,32 +215,12 @@ func (s *Server) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentReque
 		}
 		instanceIdleTTL = &value
 	}
-	// Optional: an agent may name no environment and run from the deprecated
-	// inline image and resources instead.
-	var environmentID *uuid.UUID
-	// An agent without an environment predates modes, so it is a platform one.
-	llmMode := store.LLMModePlatform
-	if req.GetEnvironmentId() != "" {
-		resolved, err := s.environmentInOrganization(ctx, req.GetEnvironmentId(), organizationID)
-		if err != nil {
-			return nil, err
-		}
-		// An agent needs an agent CLI to run. An environment that names a
-		// catalog workspace image but no agent runtime is workspace-only:
-		// usable by a sandbox, not by an agent. Environments still on the
-		// free-form image carry their CLI in the agent's init_image, so they
-		// are exempt until that field goes.
-		environment, err := s.store.GetEnvironment(ctx, resolved)
-		if err != nil {
-			return nil, toStatusError(err)
-		}
-		if environment.WorkspaceImageID != nil && environment.AgentRuntimeImageID == nil {
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"environment %s names no agent runtime image, so it has no agent CLI to run", environment.Name)
-		}
-		environmentID = &resolved
-		llmMode = environment.LLMMode
+	resolved, environment, err := s.agentEnvironment(ctx, req.GetEnvironmentId(), organizationID)
+	if err != nil {
+		return nil, err
 	}
+	environmentID := &resolved
+	llmMode := environment.LLMMode
 	// The mode decides which of the two model references is legal, so a
 	// mismatch fails when someone configures it rather than when it runs.
 	modelID, modelName, err := resolveAgentModel(llmMode, req.GetModel(), req.GetModelName())
@@ -437,17 +435,14 @@ func (s *Server) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentReque
 		update.Resources = &resources
 	}
 	if environmentProvided {
-		// An empty environment_id clears the reference rather than naming an
-		// environment, leaving the agent as one created before they existed.
-		if req.GetEnvironmentId() == "" {
-			update.ClearEnvironmentID = true
-		} else {
-			environmentID, err := s.environmentInOrganization(ctx, req.GetEnvironmentId(), previousAgent.OrganizationID)
-			if err != nil {
-				return nil, err
-			}
-			update.EnvironmentID = &environmentID
+		// An empty value used to clear the reference. It now fails the same way
+		// creating an environment-less agent does: either leaves the agent with
+		// no agent CLI.
+		environmentID, _, err := s.agentEnvironment(ctx, req.GetEnvironmentId(), previousAgent.OrganizationID)
+		if err != nil {
+			return nil, err
 		}
+		update.EnvironmentID = &environmentID
 	}
 
 	if modelProvided || environmentProvided {
@@ -1645,9 +1640,7 @@ func toProtoEnvironmentAvailability(availability store.EnvironmentAvailability) 
 // mentioned.
 func (s *Server) resolveUpdatedAgentModel(ctx context.Context, req *agentsv1.UpdateAgentRequest, previous store.Agent, update store.AgentUpdate) (uuid.UUID, string, error) {
 	environmentID := previous.EnvironmentID
-	if update.ClearEnvironmentID {
-		environmentID = nil
-	} else if update.EnvironmentID != nil {
+	if update.EnvironmentID != nil {
 		environmentID = update.EnvironmentID
 	}
 

--- a/internal/server/volume_attachment_compat_test.go
+++ b/internal/server/volume_attachment_compat_test.go
@@ -19,9 +19,7 @@ func TestListVolumeAttachmentsServesTheEnvironmentsVolumes(t *testing.T) {
 	environmentID := createTestEnvironment(ctx, t, server, organizationID, "shared")
 	mustCreateVolume(ctx, t, server, environmentID, "data", "/data")
 
-	request := createAgentRequest(organizationID, "alpha")
-	request.EnvironmentId = environmentID
-	created, err := server.CreateAgent(ctx, request)
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", environmentID))
 	if err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -50,14 +48,16 @@ func TestListVolumeAttachmentsServesTheEnvironmentsVolumes(t *testing.T) {
 	}
 }
 
-// An agent in no environment has no volumes, which is an empty list rather than
-// an error: the old orchestrator treats a failure here as an unassemblable
+// An environment with no volumes attaches none, which is an empty list rather
+// than an error: the old orchestrator treats a failure here as an unassemblable
 // agent.
-func TestListVolumeAttachmentsForAnAgentWithoutAnEnvironment(t *testing.T) {
+func TestListVolumeAttachmentsForAnEnvironmentWithoutVolumes(t *testing.T) {
 	ctx := identityContext(uuid.New())
 	server := agentEnvironmentServer(ctx, t)
+	organizationID := uuid.New()
 
-	created, err := server.CreateAgent(ctx, createAgentRequest(uuid.New(), "alpha"))
+	environmentID := createTestEnvironment(ctx, t, server, organizationID, "empty")
+	created, err := server.CreateAgent(ctx, createAgentRequest(organizationID, "alpha", environmentID))
 	if err != nil {
 		t.Fatalf("create agent: %v", err)
 	}

--- a/internal/store/agent_helpers.go
+++ b/internal/store/agent_helpers.go
@@ -131,12 +131,25 @@ func agentIDForMcp(ctx context.Context, tx pgx.Tx, mcpID uuid.UUID) (uuid.UUID, 
 	return agentID, nil
 }
 
+// agentIDsForVolume names the agents whose configuration a volume is part of.
+//
+// A volume stopped being a free-standing row reached through an attachment when
+// it became a sub-resource of what mounts it, and volume_attachments was
+// dropped with it -- so this query returned "relation does not exist" on every
+// delete and every notification since. A volume now hangs off an MCP, whose
+// agent it belongs to, or off an environment, which every agent running there
+// takes its configuration from.
 func agentIDsForVolume(ctx context.Context, queryer agentIDQueryer, volumeID uuid.UUID) ([]uuid.UUID, error) {
 	rows, err := queryer.Query(ctx,
-		`SELECT DISTINCT COALESCE(va.agent_id, mcps.agent_id)
-FROM volume_attachments va
-LEFT JOIN mcps ON va.mcp_id = mcps.id
-WHERE va.volume_id = $1`,
+		`SELECT mcps.agent_id
+FROM volumes
+JOIN mcps ON mcps.id = volumes.mcp_id
+WHERE volumes.id = $1 AND mcps.agent_id IS NOT NULL
+UNION
+SELECT agents.id
+FROM volumes
+JOIN agents ON agents.environment_id = volumes.environment_id
+WHERE volumes.id = $1`,
 		volumeID,
 	)
 	if err != nil {


### PR DESCRIPTION
`CreateAgent` accepted an agent that named no environment, and one whose environment named no agent runtime image whenever it used the free-form image rather than a catalog one. Both produce an agent the Orchestrator refuses to assemble.

It retries on every reconcile cycle and never stops: an assembly failure writes no workload record, so the start-failure backoff counts nothing and the instance is never paused or degraded. The agent is created, reported as created, goes ACTIVE, and never runs. The only trace is a line in the Orchestrator's own log — which is how it went unnoticed long enough to account for most of the e2e suite failing.

Both writes now resolve the environment through one path that refuses either shape. An empty `environment_id` on update used to clear the reference; it is refused for the same reason.

Also here: `agentIDsForVolume` still queried `volume_attachments`, dropped by migration 0024 when a volume became a sub-resource of what mounts it — so `DeleteVolume` and every volume notification answered "relation does not exist". It reads `volumes` now.

Verified on the local bundle VM with agents running from source: the go-core orchestrator suite goes from no agent workload starting at all to 36/45 passing.