### PR TITLE
Serve before backfilling

### DIFF
--- a/cmd/agents-service/main.go
+++ b/cmd/agents-service/main.go
@@ -109,8 +109,17 @@ func run() error {
 	agentsv1.RegisterAgentsServiceServer(grpcServer, agentsService)
 
 	// Environments predating the environment authorization type carry no tuples,
-	// so every check against them refuses. Idempotent, and runs before serving.
-	agentsService.BackfillEnvironmentAuthorization(ctx)
+	// so every check against them refuses.
+	//
+	// In the background, because it is one authorization write per environment
+	// and nothing waits on it: it is idempotent, it runs again on the next
+	// start, and a request arriving mid-backfill is answered by the tuples that
+	// already exist. Ahead of Serve it was O(environments) between process
+	// start and the port opening, which the liveness probe -- tcp on the gRPC
+	// port, three failures ten seconds apart -- eventually outlasts. An
+	// organization with a few hundred environments crashlooped the service on a
+	// backfill that had nothing left to do.
+	go agentsService.BackfillEnvironmentAuthorization(ctx)
 
 	// Instances whose class sets an idle limit are paused once they pass it.
 	// Started before Serve so a service that never receives a request still


### PR DESCRIPTION
The environment authorization backfill ran between process start and the port opening, and it is one authorization write per environment.

The liveness probe is tcp on the gRPC port — `delay=10s timeout=1s period=10s #failure=3` — so a service with enough environments is killed before it finishes, and restarts into the same backfill. A local platform reached that at 121 environments:

```
Warning  Unhealthy  kubelet  Liveness probe failed: dial tcp 10.42.0.249:50051: connect: connection refused
Normal   Created    kubelet  Created container: agents   (x6 over 5m41s)
agents: backfill environment d6e2de40-…: rpc error: code = Canceled desc = context canceled
agents: backfill environment authorization: list: context canceled
```

It crashlooped on work that had nothing left to do — every tuple it was writing already existed. The cost is O(environments) on *every* start, so it gets worse as an organization uses the product.

Nothing waits on it: it is idempotent, it runs again on the next start, and a request arriving while it is in flight is answered by the tuples already there — the same answer it would have got a moment later. So it goes in the background, and the port opens when the service is ready to serve.