### PR TITLE
Constrain a skill's name to a slug and require a description

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,10 +39,15 @@ func (s *Server) WithOrganizations(client OrganizationsClient) {
 
 const (
 	maxMcpNameLength   = 63
+	maxSkillNameLength = 64
 	defaultIdleTimeout = "5m"
 )
 
 var mcpNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
+
+// A skill's name is the directory the agent CLI discovers it in, so it is
+// constrained to what is a legal directory name for every CLI the platform runs.
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$`)
 
 func New(store *store.Store, authz AuthorizationWriter, identity IdentityWriter, notifications notificationsv1.NotificationsServiceClient) *Server {
 	if store == nil {
@@ -1084,6 +1089,12 @@ func (s *Server) CreateSkill(ctx context.Context, req *agentsv1.CreateSkillReque
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 	}
+	if err := validateSkillName(req.GetName()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+	}
+	if err := validateSkillDescription(req.GetDescription()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "description: %v", err)
+	}
 	skill, err := s.store.CreateSkill(ctx, store.SkillInput{
 		AgentID:     agentID,
 		Name:        req.GetName(),
@@ -1121,6 +1132,9 @@ func (s *Server) UpdateSkill(ctx context.Context, req *agentsv1.UpdateSkillReque
 	update := store.SkillUpdate{}
 	if req.Name != nil {
 		value := req.GetName()
+		if err := validateSkillName(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name: %v", err)
+		}
 		update.Name = &value
 	}
 	if req.Body != nil {
@@ -1129,6 +1143,9 @@ func (s *Server) UpdateSkill(ctx context.Context, req *agentsv1.UpdateSkillReque
 	}
 	if req.Description != nil {
 		value := req.GetDescription()
+		if err := validateSkillDescription(value); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "description: %v", err)
+		}
 		update.Description = &value
 	}
 
@@ -1582,6 +1599,28 @@ func validateMcpName(name string) error {
 	}
 	if !mcpNamePattern.MatchString(name) {
 		return fmt.Errorf("must match %s", mcpNamePattern.String())
+	}
+	return nil
+}
+
+func validateSkillName(name string) error {
+	if name == "" {
+		return fmt.Errorf("value is empty")
+	}
+	if len(name) > maxSkillNameLength {
+		return fmt.Errorf("must be at most %d characters", maxSkillNameLength)
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("must match %s", skillNamePattern.String())
+	}
+	return nil
+}
+
+// Without a description the agent CLI has nothing to match the skill against,
+// and Codex refuses to load it at all.
+func validateSkillDescription(description string) error {
+	if strings.TrimSpace(description) == "" {
+		return fmt.Errorf("value is empty")
 	}
 	return nil
 }

--- a/internal/server/skill_validation_test.go
+++ b/internal/server/skill_validation_test.go
@@ -1,0 +1,38 @@
+package server
+
+import "testing"
+
+func TestValidateSkillName(t *testing.T) {
+	valid := []string{"skill", "skill-one", "s", "release-notes-2"}
+	for _, name := range valid {
+		if err := validateSkillName(name); err != nil {
+			t.Fatalf("expected %q to be valid, got %v", name, err)
+		}
+	}
+
+	invalid := []string{"", "Skill One", "skill one", "Skill", "skill_one", "-skill", "skill-", "skill/one", "."}
+	for _, name := range invalid {
+		if err := validateSkillName(name); err == nil {
+			t.Fatalf("expected %q to be rejected", name)
+		}
+	}
+
+	long := make([]byte, maxSkillNameLength+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if err := validateSkillName(string(long)); err == nil {
+		t.Fatal("expected an over-long name to be rejected")
+	}
+}
+
+func TestValidateSkillDescription(t *testing.T) {
+	if err := validateSkillDescription("Use when drafting release notes"); err != nil {
+		t.Fatalf("expected a description to be valid, got %v", err)
+	}
+	for _, description := range []string{"", "   ", "\n"} {
+		if err := validateSkillDescription(description); err == nil {
+			t.Fatalf("expected %q to be rejected", description)
+		}
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -178,12 +178,29 @@ func TestAgentsServiceE2E(t *testing.T) {
 
 		skillResp, err := client.CreateSkill(ctx, &agentsv1.CreateSkillRequest{
 			AgentId:     agentID,
-			Name:        "Skill " + testID,
+			Name:        "skill-" + testID,
 			Body:        "skill body",
 			Description: "Skill description",
 		})
 		require.NoError(t, err)
 		skillID := skillResp.Skill.Meta.Id
+
+		_, err = client.CreateSkill(ctx, &agentsv1.CreateSkillRequest{
+			AgentId:     agentID,
+			Name:        "Skill " + testID,
+			Body:        "skill body",
+			Description: "Skill description",
+		})
+		require.Error(t, err)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		_, err = client.CreateSkill(ctx, &agentsv1.CreateSkillRequest{
+			AgentId: agentID,
+			Name:    "skill-no-description-" + testID,
+			Body:    "skill body",
+		})
+		require.Error(t, err)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		updatedSkillResp, err := client.UpdateSkill(ctx, &agentsv1.UpdateSkillRequest{
 			Id:   skillID,


### PR DESCRIPTION
A skill's name is the directory the agent CLI discovers it in, so `CreateSkill` and `UpdateSkill` now constrain it to a slug the way MCP, volume and sandbox names already are, and reject an empty description — without one the CLI has nothing to match the skill against, and Codex refuses to load it at all.

Spec: [Resource Definitions — Skill](https://github.com/agynio/architecture/blob/main/architecture/resource-definitions.md#skill), delta in `changes/2026-08-22-skills-on-the-agent-filesystem.md`.